### PR TITLE
added tests for revoke handler

### DIFF
--- a/lambda_functions/v1/tests/api/cases_handle_revoke.py
+++ b/lambda_functions/v1/tests/api/cases_handle_revoke.py
@@ -1,0 +1,73 @@
+import datetime
+from copy import deepcopy
+
+from pytest_cases import CaseData, case_name, case_tags
+
+
+@case_name("Revoke an active code")
+def case_revoke_a_code_1() -> CaseData:
+    test_data = [
+        {
+            "active": True,
+            "actor": "violet",
+            "code": "jmABs6fFaNJG",
+            "expiry_date": "30/08/2020",
+            "generated_date": "31/08/2019",
+            "last_updated_date": "26/12/2019",
+            "lpa": "mesh_end_to_end_systems",
+        }
+    ]
+
+    data = {
+        "code": "jmABs6fFaNJG",
+    }
+
+    expected_result = 1
+    expected_last_updated_date = datetime.datetime.now().strftime("%d/%m/%Y")
+    return test_data, data, expected_result, expected_last_updated_date
+
+
+@case_name("Revoke an inactive code")
+def case_revoke_a_code_2() -> CaseData:
+    test_data = [
+        {
+            "active": False,
+            "actor": "violet",
+            "code": "jmABs6fFaNJG",
+            "expiry_date": "30/08/2020",
+            "generated_date": "31/08/2019",
+            "last_updated_date": "26/12/2019",
+            "lpa": "mesh_end_to_end_systems",
+        }
+    ]
+
+    data = {
+        "code": "jmABs6fFaNJG",
+    }
+
+    expected_result = 0
+    expected_last_updated_date = "26/12/2019"
+    return test_data, data, expected_result, expected_last_updated_date
+
+
+@case_name("Try to revoke a code but it doesn't exist")
+def case_revoke_a_code_3() -> CaseData:
+    test_data = [
+        {
+            "active": True,
+            "actor": "violet",
+            "code": "jmABs6fFaNJG",
+            "expiry_date": "30/08/2020",
+            "generated_date": "31/08/2019",
+            "last_updated_date": "26/12/2019",
+            "lpa": "mesh_end_to_end_systems",
+        }
+    ]
+
+    data = {
+        "code": "not_a_code",
+    }
+
+    expected_result = 0
+    expected_last_updated_date = "26/12/2019"
+    return test_data, data, expected_result, expected_last_updated_date

--- a/lambda_functions/v1/tests/api/test_revoke_handler.py
+++ b/lambda_functions/v1/tests/api/test_revoke_handler.py
@@ -1,0 +1,31 @@
+import boto3
+
+from lambda_functions.v1.functions.lpa_codes.app.api import code_generator
+from lambda_functions.v1.functions.lpa_codes.app.api.lets_see_about_this import (
+    handle_revoke,
+)
+from pytest_cases import cases_data, CaseDataGetter
+
+from lambda_functions.v1.tests.api import cases_handle_revoke
+from lambda_functions.v1.tests.conftest import (
+    insert_test_data,
+    remove_test_data,
+)
+
+
+@cases_data(module=cases_handle_revoke)
+def test_post(mock_database, case_data: CaseDataGetter):
+    test_data, data, expected_result, expected_last_updated_date = case_data.get()
+    # Set up test data
+    insert_test_data(test_data=test_data)
+
+    result = handle_revoke(data=data)
+
+    db = boto3.resource("dynamodb")
+    after_revoke = code_generator.get_codes(database=db, code=data["code"])
+
+    assert result == expected_result
+    if after_revoke:
+        assert after_revoke[0]["last_updated_date"] == expected_last_updated_date
+
+    remove_test_data(test_data)


### PR DESCRIPTION
## Purpose

Hooked existing functions up to `/revoke` endpoint

Fixes

## Approach

Underlying logic already exists, just attaching it to the route.
And tests

## Learning

N/A

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
