### PR TITLE
In 228

### DIFF
--- a/lambda_functions/v1/functions/lpa_codes/app/api/endpoints.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/endpoints.py
@@ -23,7 +23,9 @@ def handle_create(data):
         dob = entry["dob"]
 
         # 1. expire all existing codes for LPA/Actor combo
-        code_generator.update_codes(database=db, key=key, status=False)
+        code_generator.update_codes(
+            database=db, key=key, status=False, status_details="Superseded"
+        )
 
         # 2. generate a new code
         generated_code = code_generator.generate_code(database=db)
@@ -49,7 +51,9 @@ def handle_create(data):
 def handle_revoke(data):
     db = db_connection()
 
-    update_result = code_generator.update_codes(database=db, code=data["code"])
+    update_result = code_generator.update_codes(
+        database=db, code=data["code"], status_details="Revoked"
+    )
 
     return {"codes revoked": update_result}
 

--- a/lambda_functions/v1/requirements/dev-requirements.txt
+++ b/lambda_functions/v1/requirements/dev-requirements.txt
@@ -18,3 +18,4 @@ pytest-cases
 pytest-cov
 pytest-ordering
 pytest-env
+freezegun

--- a/lambda_functions/v1/tests/api/cases_handle_create.py
+++ b/lambda_functions/v1/tests/api/cases_handle_create.py
@@ -1,8 +1,60 @@
+import copy
+
 from pytest_cases import CaseData, case_name
+
+from lambda_functions.v1.tests.conftest import test_constants
+
+default_test_data = [
+    {
+        "lpa": "eed4f597-fd87-4536-99d0-895778824861",
+        "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
+        "code": "code_1",
+        "active": True,
+        "last_updated_date": "2020-01-01",
+        "dob": "1960-06-05",
+        "generated_date": "2020-01-01",
+        "expiry_date": test_constants["EXPIRY_DATE"],
+        "status_details": "Generated",
+    },
+    {
+        "lpa": "eed4f597-fd87-4536-99d0-895778824861",
+        "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
+        "code": "code_2",
+        "active": True,
+        "last_updated_date": "2020-01-02",
+        "dob": "1960-06-05",
+        "generated_date": "2020-01-02",
+        "expiry_date": test_constants["EXPIRY_DATE"],
+        "status_details": "Generated",
+    },
+    {
+        "lpa": "productize_out_of_the_box_portals",
+        "actor": "violet",
+        "code": "code_3",
+        "active": True,
+        "last_updated_date": "2020-01-01",
+        "dob": "1960-06-05",
+        "generated_date": "2020-01-01",
+        "expiry_date": test_constants["EXPIRY_DATE"],
+        "status_details": "Generated",
+    },
+    {
+        "lpa": "productize_out_of_the_box_portals",
+        "actor": "violet",
+        "code": "code_4",
+        "active": True,
+        "last_updated_date": "2020-01-02",
+        "dob": "1960-06-05",
+        "generated_date": "2020-01-02",
+        "expiry_date": test_constants["EXPIRY_DATE"],
+        "status_details": "Generated",
+    },
+]
 
 
 @case_name("Create a single code")
 def case_create_a_code_1() -> CaseData:
+    test_data = copy.deepcopy(default_test_data)
 
     data = {
         "lpas": [
@@ -14,7 +66,7 @@ def case_create_a_code_1() -> CaseData:
         ]
     }
 
-    code = "tOhkrldOqewm"
+    code = test_constants["DEFAULT_CODE"]
 
     expected_result = {
         "codes": [
@@ -25,11 +77,12 @@ def case_create_a_code_1() -> CaseData:
             }
         ]
     }
-    return data, expected_result
+    return test_data, data, expected_result
 
 
 @case_name("Create multiple codes")
 def case_create_a_code_2() -> CaseData:
+    test_data = copy.deepcopy(default_test_data)
 
     data = {
         "lpas": [
@@ -61,7 +114,7 @@ def case_create_a_code_2() -> CaseData:
         ]
     }
 
-    code = "tOhkrldOqewm"
+    code = test_constants["DEFAULT_CODE"]
 
     expected_result = {
         "codes": [
@@ -92,4 +145,4 @@ def case_create_a_code_2() -> CaseData:
             },
         ]
     }
-    return data, expected_result
+    return test_data, data, expected_result

--- a/lambda_functions/v1/tests/api/cases_handle_revoke.py
+++ b/lambda_functions/v1/tests/api/cases_handle_revoke.py
@@ -19,6 +19,7 @@ def case_revoke_a_code_1() -> CaseData:
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
             "lpa": "mesh_end_to_end_systems",
+            "status_details": "Generated",
         }
     ]
 
@@ -27,7 +28,7 @@ def case_revoke_a_code_1() -> CaseData:
     }
 
     expected_result = {"codes revoked": 1}
-    expected_last_updated_date = date_formatter(date_obj=datetime.datetime.now())
+    expected_last_updated_date = test_constants["TODAY_ISO"]
     return test_data, data, expected_result, expected_last_updated_date
 
 
@@ -43,6 +44,7 @@ def case_revoke_a_code_2() -> CaseData:
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
             "lpa": "mesh_end_to_end_systems",
+            "status_details": "Superseded",
         }
     ]
 
@@ -67,6 +69,7 @@ def case_revoke_a_code_3() -> CaseData:
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
             "lpa": "mesh_end_to_end_systems",
+            "status_details": "Revoked",
         }
     ]
 

--- a/lambda_functions/v1/tests/api/cases_handle_validate.py
+++ b/lambda_functions/v1/tests/api/cases_handle_validate.py
@@ -145,3 +145,28 @@ def case_validate_invalid_code_3() -> CaseData:
 
     expected_result = {"actor": None}
     return test_data, data, expected_result
+
+
+@case_name("Try to validate a code that is valid and active but past its TTL")
+def case_validate_valid_code_3() -> CaseData:
+    test_data = [
+        {
+            "active": True,
+            "actor": "lightcyan",
+            "code": "t39hg7zQdE59",
+            "expiry_date": test_constants["EXPIRY_DATE_PAST"],
+            "generated_date": "2019-09-31",
+            "last_updated_date": "2019-12-26",
+            "dob": "1960-06-05",
+            "lpa": "scale_virtual_e_commerce",
+        }
+    ]
+
+    data = {
+        "lpa": "scale_virtual_e_commerce",
+        "dob": "1960-06-05",
+        "code": "t39hg7zQdE59",
+    }
+
+    expected_result = {"actor": None}
+    return test_data, data, expected_result

--- a/lambda_functions/v1/tests/api/test_create_handler.py
+++ b/lambda_functions/v1/tests/api/test_create_handler.py
@@ -1,17 +1,62 @@
+import datetime
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+from lambda_functions.v1.functions.lpa_codes.app.api.database import lpa_codes_table
 from lambda_functions.v1.functions.lpa_codes.app.api.endpoints import handle_create
 
 from pytest_cases import CaseDataGetter, cases_data
 
 from lambda_functions.v1.tests.api import cases_handle_create
-from lambda_functions.v1.tests.conftest import remove_test_data
+from lambda_functions.v1.tests.conftest import (
+    remove_test_data,
+    test_constants,
+    insert_test_data,
+)
 
 
 @cases_data(module=cases_handle_create)
 def test_post(mock_database, mock_generate_code, case_data: CaseDataGetter):
-    data, expected_result = case_data.get()
+    test_data, data, expected_result = case_data.get()
 
     result = handle_create(data=data)
 
     assert result == expected_result
 
     remove_test_data(expected_result["codes"])
+
+
+@cases_data(module=cases_handle_create)
+def test_data(mock_database, mock_generate_code, case_data: CaseDataGetter):
+    test_data, data, expected_result = case_data.get()
+
+    insert_test_data(test_data=test_data)
+
+    handle_create(data=data)
+
+    lpa = data["lpas"][0]["lpa"]
+    actor = data["lpas"][0]["actor"]
+
+    db = boto3.resource("dynamodb")
+    table = db.Table(lpa_codes_table())
+
+    query_result = table.query(
+        IndexName="key_index",
+        KeyConditionExpression=Key("lpa").eq(lpa) & Key("actor").eq(actor),
+    )
+    print(f"query_result: {query_result}")
+
+    for item in query_result["Items"]:
+
+        if item["code"] == test_constants["DEFAULT_CODE"]:
+            assert item["active"] is True
+            assert item["status_details"] == "Generated"
+            assert item["last_updated_date"] == test_constants["TODAY_ISO"]
+            assert item["generated_date"] == test_constants["TODAY_ISO"]
+            assert item["expiry_date"] == test_constants["EXPIRY_DATE"]
+        else:
+            assert item["active"] is False
+            assert item["status_details"] == "Superseded"
+
+    remove_test_data(expected_result["codes"] + test_data)

--- a/lambda_functions/v1/tests/api/test_create_handler.py
+++ b/lambda_functions/v1/tests/api/test_create_handler.py
@@ -1,5 +1,3 @@
-import datetime
-
 import boto3
 from boto3.dynamodb.conditions import Key
 
@@ -14,6 +12,7 @@ from lambda_functions.v1.tests.conftest import (
     test_constants,
     insert_test_data,
 )
+from freezegun import freeze_time
 
 
 @cases_data(module=cases_handle_create)
@@ -28,6 +27,7 @@ def test_post(mock_database, mock_generate_code, case_data: CaseDataGetter):
 
 
 @cases_data(module=cases_handle_create)
+@freeze_time("2020-01-21")
 def test_data(mock_database, mock_generate_code, case_data: CaseDataGetter):
     test_data, data, expected_result = case_data.get()
 
@@ -45,7 +45,6 @@ def test_data(mock_database, mock_generate_code, case_data: CaseDataGetter):
         IndexName="key_index",
         KeyConditionExpression=Key("lpa").eq(lpa) & Key("actor").eq(actor),
     )
-    print(f"query_result: {query_result}")
 
     for item in query_result["Items"]:
 

--- a/lambda_functions/v1/tests/api/test_revoke_handler.py
+++ b/lambda_functions/v1/tests/api/test_revoke_handler.py
@@ -8,9 +8,11 @@ from pytest_cases import cases_data, CaseDataGetter
 
 from lambda_functions.v1.tests.api import cases_handle_revoke
 from lambda_functions.v1.tests.conftest import insert_test_data, remove_test_data
+from freezegun import freeze_time
 
 
 @cases_data(module=cases_handle_revoke)
+@freeze_time("2020-01-21")
 def test_post(mock_database, case_data: CaseDataGetter):
     test_data, data, expected_result, expected_last_updated_date = case_data.get()
     # Set up test data

--- a/lambda_functions/v1/tests/api/test_revoke_handler.py
+++ b/lambda_functions/v1/tests/api/test_revoke_handler.py
@@ -1,14 +1,13 @@
 import boto3
+from boto3.dynamodb.conditions import Key
 
 from lambda_functions.v1.functions.lpa_codes.app.api import code_generator
+from lambda_functions.v1.functions.lpa_codes.app.api.database import lpa_codes_table
 from lambda_functions.v1.functions.lpa_codes.app.api.endpoints import handle_revoke
 from pytest_cases import cases_data, CaseDataGetter
 
 from lambda_functions.v1.tests.api import cases_handle_revoke
-from lambda_functions.v1.tests.conftest import (
-    insert_test_data,
-    remove_test_data,
-)
+from lambda_functions.v1.tests.conftest import insert_test_data, remove_test_data
 
 
 @cases_data(module=cases_handle_revoke)
@@ -24,6 +23,25 @@ def test_post(mock_database, case_data: CaseDataGetter):
 
     assert result == expected_result
     if after_revoke:
-        assert after_revoke[0]["last_updated_date"] == expected_last_updated_date
+        lpa = after_revoke[0]["lpa"]
+        actor = after_revoke[0]["actor"]
+
+        db = boto3.resource("dynamodb")
+        table = db.Table(lpa_codes_table())
+
+        query_result = table.query(
+            IndexName="key_index",
+            KeyConditionExpression=Key("lpa").eq(lpa) & Key("actor").eq(actor),
+        )
+
+        row_data = query_result["Items"][0]
+
+        if data["code"] == row_data["code"]:
+            assert row_data["last_updated_date"] == expected_last_updated_date
+            assert row_data["status_details"] in [
+                "Revoked",
+                "Superseded",
+            ]
+            assert row_data["active"] is False
 
     remove_test_data(test_data)

--- a/lambda_functions/v1/tests/code_generator/cases_insert_new_code.py
+++ b/lambda_functions/v1/tests/code_generator/cases_insert_new_code.py
@@ -2,6 +2,8 @@ from decimal import Decimal
 
 from pytest_cases import CaseData
 
+from lambda_functions.v1.tests.conftest import test_constants
+
 
 def case_insert_a_code() -> CaseData:
     key = {
@@ -17,9 +19,9 @@ def case_insert_a_code() -> CaseData:
             "actor": "6f41cde2-f5f2-45d9-8776-e6dcdb1b56e8",
             "code": "2gVYdRNjUHTX",
             "active": True,
-            "last_updated_date": "2020-01-21",
+            "last_updated_date": test_constants["TODAY_ISO"],
             "dob": "1960-06-05",
-            "expiry_date": Decimal("1611216000"),
+            "expiry_date": test_constants["EXPIRY_DATE"],
         }
     ]
 

--- a/lambda_functions/v1/tests/code_generator/test_insert_new_code.py
+++ b/lambda_functions/v1/tests/code_generator/test_insert_new_code.py
@@ -10,9 +10,11 @@ from lambda_functions.v1.functions.lpa_codes.app.api.code_generator import (
 from lambda_functions.v1.functions.lpa_codes.app.api.helpers import date_formatter
 from lambda_functions.v1.tests.code_generator import cases_insert_new_code
 from lambda_functions.v1.tests.conftest import test_constants
+from freezegun import freeze_time
 
 
 @cases_data(module=cases_insert_new_code)
+@freeze_time("2020-01-21")
 def test_insert_new_code(mock_database, case_data: CaseDataGetter):
     key, code, dob, expected_result = case_data.get()
     db = boto3.resource("dynamodb")

--- a/lambda_functions/v1/tests/conftest.py
+++ b/lambda_functions/v1/tests/conftest.py
@@ -15,8 +15,16 @@ import datetime
 
 test_constants = {
     "TABLE_NAME": "lpa-codes-mock",
-    "EXPIRY_DATE": Decimal(1611223200),  # 21/01/2021 @ 10:00am (UTC)
-    "TODAY": datetime.datetime(year=2020, month=1, day=21, hour=8, minute=0, second=0),
+    "EXPIRY_DATE": Decimal(1611216000),  # 21/01/2021 @ 8:00am (UTC)
+    "EXPIRY_DATE_PAST": Decimal(1577865600),  # 01/01/2020 @ 8:00am (UTC)
+    "TODAY": datetime.datetime(
+        year=2020, month=1, day=21, hour=8, minute=0, second=0
+    ),  # 21/01/2020 @ 8:00am (UTC)
+    "TODAY_ISO": datetime.datetime(
+        year=2020, month=1, day=21, hour=8, minute=0, second=0
+    ).strftime(
+        "%Y-%m-%d"
+    ),  # 2020-01-21 @8:00am (UTC)
     "DEFAULT_CODE": "tOhkrldOqewm",
 }
 

--- a/lambda_functions/v1/tests/conftest.py
+++ b/lambda_functions/v1/tests/conftest.py
@@ -15,7 +15,7 @@ import datetime
 
 test_constants = {
     "TABLE_NAME": "lpa-codes-mock",
-    "EXPIRY_DATE": Decimal(1611216000),  # 21/01/2021 @ 8:00am (UTC)
+    "EXPIRY_DATE": Decimal(1611187200),  # 21/01/2021 @ 12:00am (UTC)
     "EXPIRY_DATE_PAST": Decimal(1577865600),  # 01/01/2020 @ 8:00am (UTC)
     "TODAY": datetime.datetime(
         year=2020, month=1, day=21, hour=8, minute=0, second=0
@@ -27,16 +27,6 @@ test_constants = {
     ),  # 2020-01-21 @8:00am (UTC)
     "DEFAULT_CODE": "tOhkrldOqewm",
 }
-
-
-@pytest.fixture(autouse=True)
-def mock_datetime_now(monkeypatch):
-    class FakeDate(datetime.datetime):
-        @classmethod
-        def now(cls):
-            return test_constants["TODAY"]
-
-    monkeypatch.setattr(datetime, "datetime", FakeDate)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Purpose

Add status for codes that have been revoked 

## Approach

* added in status details to the db updates
* added some tests to check what actually went into the db
* introduced freezegun package to fix the datetime mocking problems
* bit more use of constants in the tests

## Learning

I have used all kinds of workarounds to the datetime problem, don't know how I never came across this before

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
