### PR TITLE
Make all dates relative to today

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,7 +463,7 @@ jobs:
           name: Set up ready for pact tests
           command: |
             export PACT_VERSION=$(curl -i -s -X GET https://github.com/pact-foundation/pact-ruby-standalone/releases/latest \
-            | grep "Location:" | awk -F'tag' '{print $2}' | awk -F'/v' '{print $2}' | sed 's/.$//')
+            | grep "location:" | awk -F'tag' '{print $2}' | awk -F'/v' '{print $2}' | sed 's/.$//')
             wget https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-x86_64.tar.gz
             tar xzf pact-${PACT_VERSION}-linux-x86_64.tar.gz
       - run:

--- a/lambda_functions/v1/tests/api/test_create_handler.py
+++ b/lambda_functions/v1/tests/api/test_create_handler.py
@@ -2,7 +2,7 @@ import boto3
 import pytest
 from boto3.dynamodb.conditions import Key
 import logging
-
+import datetime
 from lambda_functions.v1.functions.lpa_codes.app.api import code_generator
 from lambda_functions.v1.functions.lpa_codes.app.api.database import lpa_codes_table
 from lambda_functions.v1.functions.lpa_codes.app.api.endpoints import handle_create
@@ -32,7 +32,7 @@ def test_post(mock_database, mock_generate_code, case_data: CaseDataGetter):
 
 
 @cases_data(module=cases_handle_create)
-@freeze_time("2020-01-21")
+@freeze_time(datetime.date.today())
 def test_data(mock_database, mock_generate_code, case_data: CaseDataGetter):
     test_data, data, expected_result, expected_status_code = case_data.get()
 

--- a/lambda_functions/v1/tests/api/test_revoke_handler.py
+++ b/lambda_functions/v1/tests/api/test_revoke_handler.py
@@ -1,5 +1,5 @@
 import logging
-
+import datetime
 import boto3
 from boto3.dynamodb.conditions import Key
 
@@ -14,7 +14,7 @@ from freezegun import freeze_time
 
 
 @cases_data(module=cases_handle_revoke)
-@freeze_time("2020-01-21")
+@freeze_time(datetime.date.today())
 def test_post(mock_database, case_data: CaseDataGetter):
     (
         test_data,

--- a/lambda_functions/v1/tests/code_generator/test_insert_new_code.py
+++ b/lambda_functions/v1/tests/code_generator/test_insert_new_code.py
@@ -14,7 +14,7 @@ from freezegun import freeze_time
 
 
 @cases_data(module=cases_insert_new_code)
-@freeze_time("2020-01-21")
+@freeze_time(datetime.date.today())
 def test_insert_new_code(mock_database, case_data: CaseDataGetter):
     key, code, dob, expected_result, expected_row = case_data.get()
     db = boto3.resource("dynamodb")

--- a/lambda_functions/v1/tests/conftest.py
+++ b/lambda_functions/v1/tests/conftest.py
@@ -11,13 +11,14 @@ from lambda_functions.v1.functions.lpa_codes.app.api import (
     endpoints,
 )
 
+today = datetime.date.today()
 
 test_constants = {
     "TABLE_NAME": "lpa-codes-mock",
-    "EXPIRY_DATE": Decimal((datetime.date.today() + datetime.timedelta(days=365)).strftime('%s')),
+    "EXPIRY_DATE": Decimal((today + datetime.timedelta(days=365)).strftime("%s")),
     "EXPIRY_DATE_PAST": Decimal(1577865600),  # 01/01/2020 @ 8:00am (UTC)
-    "TODAY": datetime.date.today(),
-    "TODAY_ISO": datetime.date.today().strftime("%Y-%m-%d"),
+    "TODAY": today,
+    "TODAY_ISO": today.strftime("%Y-%m-%d"),
     "DEFAULT_CODE": "tOhkrldOqewm",
 }
 

--- a/lambda_functions/v1/tests/conftest.py
+++ b/lambda_functions/v1/tests/conftest.py
@@ -5,26 +5,19 @@ import boto3
 import pytest
 from flask import request
 from moto import mock_dynamodb2
-
+import datetime
 from lambda_functions.v1.functions.lpa_codes.app.api import (
     code_generator,
     endpoints,
 )
-import datetime
 
 
 test_constants = {
     "TABLE_NAME": "lpa-codes-mock",
-    "EXPIRY_DATE": Decimal(1611187200),  # 21/01/2021 @ 12:00am (UTC)
+    "EXPIRY_DATE": Decimal((datetime.date.today() + datetime.timedelta(days=365)).strftime('%s')),
     "EXPIRY_DATE_PAST": Decimal(1577865600),  # 01/01/2020 @ 8:00am (UTC)
-    "TODAY": datetime.datetime(
-        year=2020, month=1, day=21, hour=8, minute=0, second=0
-    ),  # 21/01/2020 @ 8:00am (UTC)
-    "TODAY_ISO": datetime.datetime(
-        year=2020, month=1, day=21, hour=8, minute=0, second=0
-    ).strftime(
-        "%Y-%m-%d"
-    ),  # 2020-01-21 @8:00am (UTC)
+    "TODAY": datetime.date.today(),
+    "TODAY_ISO": datetime.date.today().strftime("%Y-%m-%d"),
     "DEFAULT_CODE": "tOhkrldOqewm",
 }
 


### PR DESCRIPTION
## Purpose

Fixes test failures that were comparing against a fixed expiry date that has now passed

## Approach

Changed expiry date test constants to be relative to today

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
