### PR TITLE
UML-2553 - Document new /code path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,7 +413,7 @@ jobs:
   pact_verification:
     docker:
       # Primary container image where all the steps run.
-      - image: circleci/python:3.8.10
+      - image: cimg/python:3.8.10
         auth:
           username: $DOCKER_USER
           password: $DOCKER_ACCESS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ orbs:
     executors:
       python_with_tfvars:
         docker:
-          - image: circleci/python:3.8.10
+          - image: cimg/python:3.8.10
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN
@@ -148,7 +148,7 @@ orbs:
           TF_SHA256SUM: 171ef5a4691b6f86eab524feaf9a52d5221c875478bd63dd7e55fef3939f7fd4
       python:
         docker:
-          - image: circleci/python:3.8.10
+          - image: cimg/python:3.8.10
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,42 @@
 ---
-- repo: git://github.com/p1c2u/openapi-spec-validator
-  rev: master
-  hooks:
-  - id: openapi-spec-validator
-    name: openapi-spec-validator
-    entry: openapi-spec-validator
-    description: Hook to validate Open API specs.
-    language: python
-    files: .*lpa-codes-openapi.*\.(json|yaml|yml)
-#- repo: https://github.com/adrienverge/yamllint.git
-#  rev: v1.17.0
-#  hooks:
-#    - id: yamllint
-#      args: [-c=./.yamllint]
-- repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.19.0
-  hooks:
-    - id: terraform_fmt
-    - id: terraform_validate
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.4.0
-  hooks:
-    - id: trailing-whitespace
-    - id: detect-private-key
-    - id: flake8
-      args: ['--ignore=W503', '--exclude=docs/supportscripts/*']
-    - id: trailing-whitespace
-      args: [--markdown-linebreak-ext=md]
-- repo: https://github.com/ambv/black
-  rev: stable
-  hooks:
-    - id: black
-      language_version: python3.7
--   repo: https://github.com/Yelp/detect-secrets
-    rev: v0.13.0
+
+
+  - repo: https://github.com/p1c2u/openapi-spec-validator
+    rev:  0.4.0
     hooks:
-    -   id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
+    - id: openapi-spec-validator
+      name: openapi-spec-validator
+      entry: openapi-spec-validator
+      description: Hook to validate Open API specs.
+      language: python
+      files: .*lpa-codes-openapi.*\.(json|yaml|yml)
+  #- repo: https://github.com/adrienverge/yamllint.git
+  #  rev: v1.17.0
+  #  hooks:
+  #    - id: yamllint
+  #      args: [-c=./.yamllint]
+  - repo: git://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.19.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: detect-private-key
+      - id: flake8
+        args: ['--ignore=W503', '--exclude=docs/supportscripts/*']
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+      - id: black
+        language_version: python3.7
+
+  -   repo: https://github.com/Yelp/detect-secrets
+      rev: v1.2.0
+      hooks:
+      -   id: detect-secrets
+          args: ['--baseline', '.secrets.baseline']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,6 @@
   hooks:
     - id: black
       language_version: python3.7
-
 -   repo: https://github.com/Yelp/detect-secrets
     rev: v1.2.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,42 +1,42 @@
 ---
 
 
-  - repo: https://github.com/p1c2u/openapi-spec-validator
-    rev:  0.4.0
-    hooks:
-    - id: openapi-spec-validator
-      name: openapi-spec-validator
-      entry: openapi-spec-validator
-      description: Hook to validate Open API specs.
-      language: python
-      files: .*lpa-codes-openapi.*\.(json|yaml|yml)
-  #- repo: https://github.com/adrienverge/yamllint.git
-  #  rev: v1.17.0
-  #  hooks:
-  #    - id: yamllint
-  #      args: [-c=./.yamllint]
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.19.0
-    hooks:
-      - id: terraform_fmt
-      - id: terraform_validate
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
-    hooks:
-      - id: trailing-whitespace
-      - id: detect-private-key
-      - id: flake8
-        args: ['--ignore=W503', '--exclude=docs/supportscripts/*']
-      - id: trailing-whitespace
-        args: [--markdown-linebreak-ext=md]
-  - repo: https://github.com/ambv/black
-    rev: stable
-    hooks:
-      - id: black
-        language_version: python3.7
+- repo: https://github.com/p1c2u/openapi-spec-validator
+  rev:  0.4.0
+  hooks:
+  - id: openapi-spec-validator
+    name: openapi-spec-validator
+    entry: openapi-spec-validator
+    description: Hook to validate Open API specs.
+    language: python
+    files: .*lpa-codes-openapi.*\.(json|yaml|yml)
+#- repo: https://github.com/adrienverge/yamllint.git
+#  rev: v1.17.0
+#  hooks:
+#    - id: yamllint
+#      args: [-c=./.yamllint]
+- repo: git://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.19.0
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_validate
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.4.0
+  hooks:
+    - id: trailing-whitespace
+    - id: detect-private-key
+    - id: flake8
+      args: ['--ignore=W503', '--exclude=docs/supportscripts/*']
+    - id: trailing-whitespace
+      args: [--markdown-linebreak-ext=md]
+- repo: https://github.com/ambv/black
+  rev: stable
+  hooks:
+    - id: black
+      language_version: python3.7
 
-  -   repo: https://github.com/Yelp/detect-secrets
-      rev: v1.2.0
-      hooks:
-      -   id: detect-secrets
-          args: ['--baseline', '.secrets.baseline']
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: v1.2.0
+    hooks:
+    -   id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']

--- a/lambda_functions/v1/functions/lpa_codes/app/api/resources.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/resources.py
@@ -146,7 +146,9 @@ def actor_code_exists_route():
     everything to explode if a required field is missing we are checking here also.
 
     Returns:
-        if payload is valid - dict of matching code generated date, status code
+        if payload is valid - dict of matching code with active status, actor Uid,
+        actor dob, code expiry date, code generated date, code last updated date,
+        lpa Uid and status details.
         if payload is invalid - 400
     """
     post_data = request.get_json()

--- a/lambda_functions/v1/functions/lpa_codes/app/api/resources.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/resources.py
@@ -168,3 +168,33 @@ def actor_code_exists_route():
     result, status_code = handle_exists(data=post_data)
 
     return jsonify(result), status_code
+
+
+@api.route("/code", methods=["POST"])
+def actor_code_details_route():
+    """
+    Returns data for an Actor Activation code
+
+    Payload *should* be validated by API-Gateway before it gets here, but as it causes
+    everything to explode if a required field is missing we are checking here also.
+
+    Returns:
+        if payload is valid - dict of matching code generated date, status code
+        if payload is invalid - 400
+    """
+    post_data = request.get_json()
+
+    try:
+        code = post_data["code"]
+    except KeyError as e:
+        logger.debug(f"Missing param from request: {e}")
+        return abort(400)
+
+    if "" in [code]:
+        logger.debug(
+            f"Empty param in request: "
+            f"{[i for i in [code] if i == '']}"
+        )
+        return abort(400)
+
+    raise NotImplementedError

--- a/lambda_functions/v1/functions/lpa_codes/app/api/resources.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/resources.py
@@ -146,9 +146,7 @@ def actor_code_exists_route():
     everything to explode if a required field is missing we are checking here also.
 
     Returns:
-        if payload is valid - dict of matching code with active status, actor Uid,
-        actor dob, code expiry date, code generated date, code last updated date,
-        lpa Uid and status details.
+        if payload is valid - dict of matching code generated date, status code
         if payload is invalid - 400
     """
     post_data = request.get_json()
@@ -181,7 +179,9 @@ def actor_code_details_route():
     everything to explode if a required field is missing we are checking here also.
 
     Returns:
-        if payload is valid - dict of matching code generated date, status code
+        if payload is valid - dict of matching code with active status, actor Uid,
+        actor dob, code expiry date, code generated date, code last updated date,
+        lpa Uid and status details.
         if payload is invalid - 400
     """
     post_data = request.get_json()

--- a/lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml
+++ b/lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml
@@ -139,13 +139,13 @@ paths:
                         pattern: '[0-9]{4}-[0-9]{2}-[0-9]{2}$'
               additionalProperties: false
               example:
-                 lpas:
-                   - lpa: "eed4f597-fd87-4536-99d0-895778824861"
-                     actor: "12ad81a9-f89d-4804-99f5-7c0c8669ac9b"
-                     dob: "1960-06-05"
-                   - lpa: "eed4f597-fd87-4536-99d0-895778824861"
-                     actor: "9a619d46-8712-4bfb-a49f-c14914ff319d"
-                     dob: "1983-08-20"
+                  lpas:
+                    - lpa: "eed4f597-fd87-4536-99d0-895778824861"
+                      actor: "12ad81a9-f89d-4804-99f5-7c0c8669ac9b"
+                      dob: "1960-06-05"
+                    - lpa: "eed4f597-fd87-4536-99d0-895778824861"
+                      actor: "9a619d46-8712-4bfb-a49f-c14914ff319d"
+                      dob: "1983-08-20"
       responses:
         201:
           description: OK
@@ -370,8 +370,6 @@ paths:
             application/vnd.opg-data.v1+json:
               schema:
                 $ref: '#/components/schemas/Error503'
-
-
   /exists:
     post:
       summary: "Checks if a code exists for a specific actor on an LPA"
@@ -458,6 +456,89 @@ paths:
             application/vnd.opg-data.v1+json:
               schema:
                 $ref: '#/components/schemas/Error503'
+  /code:
+    post:
+      summary: "Returns all details for a code"
+      description: "Returns all details for a code"
+      operationId: api.resources.actor_code_details_route
+      security:
+        - sigv4: []
+      x-amazon-apigateway-request-validator: "all"
+      x-amazon-apigateway-integration:
+        uri: arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${region}:${account_id}:function:$${stageVariables.lpa_codes_function_name}/invocations
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        httpMethod: "POST"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws_proxy"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+              example:
+                code: "YsSu4iAztUXm"
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodeDetails'
+        400:
+          description: Generic bad request (generally invalid syntax)
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        401:
+          description: Unauthorised (no current user and there should be)
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: Forbidden - The current user is forbidden from accessing this data (in this way)
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        404:
+          description: That URL is not a valid route, or the item resource does not exist
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        413:
+          description: Payload too large
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error413'
+        415:
+          description: Unsupported media type
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error415'
+        500:
+          description: Something unexpected happened and it is the API"s fault
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+        503:
+          description: Service Unavailable - please try again later
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error503'
 
 components:
   securitySchemes:
@@ -482,13 +563,13 @@ components:
               code:
                 type: string
       example:
-          codes:
-          - lpa: "eed4f597-fd87-4536-99d0-895778824861"
-            actor: "12ad81a9-f89d-4804-99f5-7c0c8669ac9b"
-            code: "YsSu4iAztUXm"
-          - lpa: "eed4f597-fd87-4536-99d0-895778824861"
-            actor: "9a619d46-8712-4bfb-a49f-c14914ff319d"
-            code: "aEYVS6i9zSwy"
+        codes:
+        - lpa: "eed4f597-fd87-4536-99d0-895778824861"
+          actor: "12ad81a9-f89d-4804-99f5-7c0c8669ac9b"
+          code: "YsSu4iAztUXm"
+        - lpa: "eed4f597-fd87-4536-99d0-895778824861"
+          actor: "9a619d46-8712-4bfb-a49f-c14914ff319d"
+          code: "aEYVS6i9zSwy"
       required:
         - codes
     ValidateCode:
@@ -511,6 +592,51 @@ components:
       required:
         - lpa
         - actor
+    CodeDetails:
+      properties:
+        active:
+          type: boolean
+        actor:
+          type: string
+        code:
+          type: string
+        dob:
+          type: string
+          format: date
+        expiry_date:
+          type: string
+          format: date
+        generated_date:
+          type: string
+          format: date
+        last_updated_date:
+          type: string
+          format: date
+        lpa:
+          type: string
+        status_details:
+          type: string
+      example:
+        active: true
+        code: "YsSu4iAztUXm"
+        last_updated_date: 2022-08-20
+        status_details: "Generated"
+        expiry_date: 2023-08-20
+        dob: 1983-08-20
+        generated_date: 2022-08-20
+        lpa: "eed4f597-fd87-4536-99d0-895778824861"
+        actor: "12ad81a9-f89d-4804-99f5-7c0c8669ac9b"
+      required:
+        - active
+        - actor
+        - code
+        - dob
+        - expiry_date
+        - generated_date
+        - last_updated_date
+        - lpa
+        - status_details
+
     Error400:
       type: object
       required:
@@ -759,4 +885,3 @@ components:
                   x-ray:
                     type: string
                     example: "93c330d4-7d84-4c1b-8fdb-54cec5bfe747"
-

--- a/lambda_functions/v1/requirements/dev-requirements.txt
+++ b/lambda_functions/v1/requirements/dev-requirements.txt
@@ -10,7 +10,7 @@ Jinja2==2.11.3
 MarkupSafe==1.1.1
 python-dotenv==0.13.0
 Werkzeug==1.0.1
-openapi-spec-validator==0.3.0
+openapi-spec-validator==0.4.0
 requests
 boto3
 moto


### PR DESCRIPTION
## Purpose

The UaL admin application needs to return all details for a code

## Approach

- update openapi-spec validator dependency and pre-commit hook
- update detect-secrets pre-commit hook
- define a new path for /code
- define a new response for code details
- add a resource for /code that raises a NotImplemented error
- migrate from depcrecated CircleCI convenience images

## Learning

- https://swagger.io/docs/specification/data-models/data-types/
- https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* ~I have added tests to prove my work~
* ~The product team have tested these changes~
