### PR TITLE
Migrate to current Pact verification library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,6 @@ parameters:
   run_commit_to_main:
     type: boolean
     default: true
-  run_verify_pact:
-    type: boolean
-    default: false
   consumerversion:
     type: string
     default: ""
@@ -400,75 +397,6 @@ jobs:
                   echo "Switching workspace to default so we can remove branch workspace"
                   export TF_WORKSPACE=default
                   terraform workspace delete "${WORKSPACE_TO_DELETE}" || echo "no workspace to remove"
-  pact_verification:
-    docker:
-      # Primary container image where all the steps run.
-      - image: cimg/python:3.8.10
-      # Service container image made available to the primary container at `host: localhost`
-      - image: amazon/dynamodb-local:latest
-        entrypoint: ["java", "-Xmx1G", "-jar", "DynamoDBLocal.jar"]
-    working_directory: ~/project
-    parameters:
-    steps:
-      - checkout
-      - run:
-          name: Set BASH_ENV
-          command: ~/project/.circleci/set_env.sh >> $BASH_ENV
-      - run:
-          name: install requirements mock rest api
-          command: |
-            cd ~/project/lambda_functions/${API_VERSION}/requirements
-            pip3 install -r pact-requirements.txt
-      - run:
-          name: spin up mock rest api
-          command: |
-            cd ~/project/lambda_functions/"${API_VERSION}"/functions/lpa_codes/app
-            export PYTHONPATH="${PYTHONPATH}:/home/circleci/project"
-            python3 lpa_codes_mock.py
-          background: true
-      - run:
-          name: check mock rest api started
-          command: |
-            sleep 3
-            if [ `netstat -tulpn | grep 4343 | wc -l` -gt 0 ]
-            then
-            echo "LPA Codes Rest API Service Started Correctly"
-            else
-            echo "LPA Codes Rest API Service Not Started"
-            fi
-      - run:
-          name: Set up ready for pact tests
-          command: |
-            export PACT_VERSION=$(curl -i -s -X GET https://github.com/pact-foundation/pact-ruby-standalone/releases/latest \
-            | grep "location:" | awk -F'tag' '{print $2}' | awk -F'/v' '{print $2}' | sed 's/.$//')
-            wget https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-x86_64.tar.gz
-            tar xzf pact-${PACT_VERSION}-linux-x86_64.tar.gz
-      - run:
-          name: Run the create table endpoint
-          command: |
-            curl -X POST http://127.0.0.1:4343/setup/dynamodb/create/table
-      - run:
-          name: Set up the data in tables
-          command: |
-            curl -X POST -d '{"consumer": "sirius", "state": "generated code exists and active"}' \
-            -H 'Content-Type: application/json' http://localhost:4343/setup/state
-      - lpa-codes/pact_install
-      - run:
-          name: verify pact
-          command: |
-            if [ "${CIRCLE_BRANCH}" = "main" ]; then publish_arg="--publish-verification-results"; else publish_arg=""; fi;
-            ./pact/bin/pact-provider-verifier \
-            --broker-username ${PACT_BROKER_USER} \
-            --broker-password ${PACT_BROKER_PASS} \
-            --provider-app-version ${GIT_COMMIT_PROVIDER} \
-            --provider-base-url http://localhost:4343/v1 \
-            --provider-version-tag ${CIRCLE_BRANCH} \
-            --pact-broker-base-url ${PACT_BROKER_BASE_URL} \
-            --provider ${PACT_PROVIDER} \
-            --custom-provider-header "Authorization: asdf1234567890" \
-            --consumer-version-tag master \
-            $publish_arg
-          working_directory: ~/project
   workspace_protection:
     executor: lpa-codes/python_with_tfvars
     resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ parameters:
     default: true
   run_verify_pact:
     type: boolean
-    default: true
+    default: false
   consumerversion:
     type: string
     default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ parameters:
   run_commit_to_main:
     type: boolean
     default: true
+  run_verify_pact:
+    type: boolean
+    default: true
   consumerversion:
     type: string
     default: ""
@@ -397,6 +400,75 @@ jobs:
                   echo "Switching workspace to default so we can remove branch workspace"
                   export TF_WORKSPACE=default
                   terraform workspace delete "${WORKSPACE_TO_DELETE}" || echo "no workspace to remove"
+  pact_verification:
+    docker:
+      # Primary container image where all the steps run.
+      - image: cimg/python:3.8.10
+      # Service container image made available to the primary container at `host: localhost`
+      - image: amazon/dynamodb-local:latest
+        entrypoint: ["java", "-Xmx1G", "-jar", "DynamoDBLocal.jar"]
+    working_directory: ~/project
+    parameters:
+    steps:
+      - checkout
+      - run:
+          name: Set BASH_ENV
+          command: ~/project/.circleci/set_env.sh >> $BASH_ENV
+      - run:
+          name: install requirements mock rest api
+          command: |
+            cd ~/project/lambda_functions/${API_VERSION}/requirements
+            pip3 install -r pact-requirements.txt
+      - run:
+          name: spin up mock rest api
+          command: |
+            cd ~/project/lambda_functions/"${API_VERSION}"/functions/lpa_codes/app
+            export PYTHONPATH="${PYTHONPATH}:/home/circleci/project"
+            python3 lpa_codes_mock.py
+          background: true
+      - run:
+          name: check mock rest api started
+          command: |
+            sleep 3
+            if [ `netstat -tulpn | grep 4343 | wc -l` -gt 0 ]
+            then
+            echo "LPA Codes Rest API Service Started Correctly"
+            else
+            echo "LPA Codes Rest API Service Not Started"
+            fi
+      - run:
+          name: Set up ready for pact tests
+          command: |
+            export PACT_VERSION=$(curl -i -s -X GET https://github.com/pact-foundation/pact-ruby-standalone/releases/latest \
+            | grep "location:" | awk -F'tag' '{print $2}' | awk -F'/v' '{print $2}' | sed 's/.$//')
+            wget https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-x86_64.tar.gz
+            tar xzf pact-${PACT_VERSION}-linux-x86_64.tar.gz
+      - run:
+          name: Run the create table endpoint
+          command: |
+            curl -X POST http://127.0.0.1:4343/setup/dynamodb/create/table
+      - run:
+          name: Set up the data in tables
+          command: |
+            curl -X POST -d '{"consumer": "sirius", "state": "generated code exists and active"}' \
+            -H 'Content-Type: application/json' http://localhost:4343/setup/state
+      - lpa-codes/pact_install
+      - run:
+          name: verify pact
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "main" ]; then publish_arg="--publish-verification-results"; else publish_arg=""; fi;
+            ./pact/bin/pact-provider-verifier \
+            --broker-username ${PACT_BROKER_USER} \
+            --broker-password ${PACT_BROKER_PASS} \
+            --provider-app-version ${GIT_COMMIT_PROVIDER} \
+            --provider-base-url http://localhost:4343/v1 \
+            --provider-version-tag ${CIRCLE_BRANCH} \
+            --pact-broker-base-url ${PACT_BROKER_BASE_URL} \
+            --provider ${PACT_PROVIDER} \
+            --custom-provider-header "Authorization: asdf1234567890" \
+            --consumer-version-tag master \
+            $publish_arg
+          working_directory: ~/project
   workspace_protection:
     executor: lpa-codes/python_with_tfvars
     resource_class: small

--- a/.circleci/set_env.sh
+++ b/.circleci/set_env.sh
@@ -2,7 +2,7 @@
 set -e
 PACT_BROKER_USER="admin"
 PACT_BROKER_BASE_URL="https://pact-broker.api.opg.service.justice.gov.uk"
-PACT_PROVIDER="lpa-codes"
+PACT_PROVIDER="data-lpa-codes"
 PACT_CONSUMER="sirius"
 SIRIUS_GITHUB_URL="api.github.com/repos/ministryofjustice/opg-sirius"
 ACCOUNT="997462338508"

--- a/.github/workflows/pact-provider-verification.yml
+++ b/.github/workflows/pact-provider-verification.yml
@@ -1,0 +1,47 @@
+name: Pact Provider Verification
+
+on:
+  repository_dispatch:
+    types: [provider-verification]
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Provider verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: docker-compose up -d
+      - name: Setup tables
+        run: curl -X POST http://127.0.0.1:4343/setup/dynamodb/create/table
+      - name: Verify specified Pact
+        if: ${{ github.event_name == "repository_dispatch" }}
+        run: |
+          docker-compose run --rm pact-verifier \
+            --provider-version=$(git rev-parse HEAD) \
+            --provider-branch=main \
+            --publish \
+            --user=admin \
+            --password=${{ secrets.PACT_BROKER_PASSWORD }} \
+            --url=${{ github.event.client_payload.pact_url }}
+      - name: Verify pacts, including pending
+        if: ${{ github.event_name == "push" }}
+        run: |
+          docker-compose run --rm pact-verifier \
+            --provider-version=$(git rev-parse HEAD) \
+            --provider-branch=main \
+            --publish \
+            --user=admin \
+            --password=${{ secrets.PACT_BROKER_PASSWORD }} \
+            --enable-pending
+      - name: Verify pacts are still upheld
+        if: ${{ github.event_name == "pull_request" }}
+        run: |
+          docker-compose run --rm pact-verifier \
+            --provider-version=$(git rev-parse HEAD) \
+            --provider-branch=${{ github.ref_name }}

--- a/.github/workflows/pact-provider-verification.yml
+++ b/.github/workflows/pact-provider-verification.yml
@@ -15,7 +15,7 @@ jobs:
     name: Provider verification
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: docker-compose up -d api_gateway
       - name: Wait for container
         run: timeout 60s sh -c 'until curl -q -X POST localhost:4343/v1/create | grep 401; do echo "Waiting for table-helper to be healthy..."; sleep 2; done'
@@ -42,7 +42,7 @@ jobs:
             --publish \
             --user=admin \
             --password=${{ secrets.PACT_BROKER_PASSWORD }} \
-            --consumer-version-tags=main \
+            --consumer-version-selectors='{"mainBranch": true}' \
             --enable-pending
       - name: Verify pacts are still upheld
         if: ${{ github.event_name == 'pull_request' }}
@@ -50,4 +50,4 @@ jobs:
           docker-compose run --rm pact-verifier \
             --provider-version=$(git rev-parse HEAD) \
             --provider-branch=${{ github.head_ref }} \
-            --consumer-version-tags=main
+            --consumer-version-selectors='{"mainBranch": true}'

--- a/.github/workflows/pact-provider-verification.yml
+++ b/.github/workflows/pact-provider-verification.yml
@@ -51,5 +51,3 @@ jobs:
             --provider-version=$(git rev-parse HEAD) \
             --provider-branch=${{ github.head_ref }} \
             --consumer-version-tags=main
-      - if: always()
-        run: docker-compose logs

--- a/.github/workflows/pact-provider-verification.yml
+++ b/.github/workflows/pact-provider-verification.yml
@@ -16,11 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: docker-compose up -d
-      - name: Setup tables
-        run: curl -X POST http://127.0.0.1:4343/setup/dynamodb/create/table
+      - run: docker-compose up -d api_gateway
+      - name: Wait for container
+        run: timeout 60s sh -c 'until curl -q -X POST localhost:4343/v1/create | grep 401; do echo "Waiting for table-helper to be healthy..."; sleep 2; done'
+      - name: Wait for container
+        run: timeout 60s sh -c 'until curl -q localhost:8000; do echo "Waiting for dynamodb to be healthy..."; sleep 2; done'
+      - name: Create table
+        run: curl -q -X POST http://localhost:4343/setup/dynamodb/create/table
       - name: Verify specified Pact
-        if: ${{ github.event_name == "repository_dispatch" }}
+        if: ${{ github.event_name == 'repository_dispatch' }}
         run: |
           docker-compose run --rm pact-verifier \
             --provider-version=$(git rev-parse HEAD) \
@@ -30,7 +34,7 @@ jobs:
             --password=${{ secrets.PACT_BROKER_PASSWORD }} \
             --url=${{ github.event.client_payload.pact_url }}
       - name: Verify pacts, including pending
-        if: ${{ github.event_name == "push" }}
+        if: ${{ github.event_name == 'push' }}
         run: |
           docker-compose run --rm pact-verifier \
             --provider-version=$(git rev-parse HEAD) \
@@ -38,10 +42,14 @@ jobs:
             --publish \
             --user=admin \
             --password=${{ secrets.PACT_BROKER_PASSWORD }} \
+            --consumer-version-tags=main \
             --enable-pending
       - name: Verify pacts are still upheld
-        if: ${{ github.event_name == "pull_request" }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           docker-compose run --rm pact-verifier \
             --provider-version=$(git rev-parse HEAD) \
-            --provider-branch=${{ github.ref_name }}
+            --provider-branch=${{ github.head_ref }} \
+            --consumer-version-tags=main
+      - if: always()
+        run: docker-compose logs

--- a/README.md
+++ b/README.md
@@ -137,14 +137,7 @@ Then assuming the relative path is right to pact-provider-verifier, you can veri
 contract against our mock as below.
 
 ```
-../pact/bin/pact-provider-verifier --provider-base-url=http://localhost:4343/v1 \
---custom-provider-header 'Authorization: asdf1234567890' \
---pact-broker-base-url="http://localhost:9292" \
---provider="lpa-codes" \
---consumer-version-tag=v1 \
---provider-version-tag=v1 \
---publish-verification-results \
---provider-app-version=1.2.3
+docker-compose run --rm pact-verifier
 ```
 
 You can then see the verified results in the pact broker through your web browser. Go to:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,3 +57,14 @@ services:
       default:
         aliases:
           - lpa-codes.local
+
+  pact-verifier:
+    image: pactfoundation/pact-ref-verifier
+    entrypoint:
+      - pact_verifier_cli
+      - --hostname=table-helper
+      - --port=4343
+      - --base-path=/v1/
+      - "--header=Authorization=asdf1234567890"
+      - --broker-url=https://pact-broker.api.opg.service.justice.gov.uk/
+      - --provider-name=lpa-codes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,4 +67,4 @@ services:
       - --base-path=/v1/
       - "--header=Authorization=asdf1234567890"
       - --broker-url=https://pact-broker.api.opg.service.justice.gov.uk/
-      - --provider-name=lpa-codes
+      - --provider-name=data-lpa-codes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     depends_on:
       - dynamodb
     environment:
-      LOCAL_URL: host.docker.internal
+      LOCAL_URL: dynamodb
       ENVIRONMENT: local
       AWS_ACCESS_KEY_ID: testing
       AWS_SECRET_ACCESS_KEY: testing
@@ -62,7 +62,7 @@ services:
     image: pactfoundation/pact-ref-verifier
     entrypoint:
       - pact_verifier_cli
-      - --hostname=table-helper
+      - --hostname=api_gateway
       - --port=4343
       - --base-path=/v1/
       - "--header=Authorization=asdf1234567890"

--- a/docs/support_files/pacttestcontract.json
+++ b/docs/support_files/pacttestcontract.json
@@ -3,7 +3,7 @@
     "name": "sirius"
   },
   "provider": {
-    "name": "lpa-codes"
+    "name": "data-lpa-codes"
   },
   "interactions": [
     {

--- a/docs/support_files/sirius_contract.json
+++ b/docs/support_files/sirius_contract.json
@@ -3,7 +3,7 @@
     "name": "sirius"
   },
   "provider": {
-    "name": "lpa-codes"
+    "name": "data-lpa-codes"
   },
   "interactions": [
     {

--- a/lambda_functions/v1/functions/lpa_codes/app/api/database.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/database.py
@@ -19,7 +19,7 @@ def db_connection():
 
     if os.environ.get("ENVIRONMENT") in ["ci", "local"]:
         if os.environ.get("LOCAL_URL"):
-            url = "host.docker.internal"
+            url = os.environ.get("LOCAL_URL")
         else:
             url = "localhost"
         conn = boto3.resource(

--- a/lambda_functions/v1/tests/other/test_db_connection.py
+++ b/lambda_functions/v1/tests/other/test_db_connection.py
@@ -32,7 +32,7 @@ def test_db_connection(monkeypatch, caplog):
         assert "localhost" in caplog.text
 
     monkeypatch.setenv("ENVIRONMENT", "local")
-    monkeypatch.setenv("LOCAL_URL", "local_url")
+    monkeypatch.setenv("LOCAL_URL", "host.docker.internal")
 
     db_connection()
 
@@ -50,7 +50,7 @@ def test_db_connection(monkeypatch, caplog):
         assert "localhost" in caplog.text
 
     monkeypatch.setenv("ENVIRONMENT", "ci")
-    monkeypatch.setenv("LOCAL_URL", "local_url")
+    monkeypatch.setenv("LOCAL_URL", "host.docker.internal")
 
     db_connection()
 

--- a/pact/example/lpa-codes-pact-v1.json
+++ b/pact/example/lpa-codes-pact-v1.json
@@ -3,7 +3,7 @@
     "name": "sirius"
   },
   "provider": {
-    "name": "lpa-codes"
+    "name": "data-lpa-codes"
   },
   "interactions": [{
       "_id": "cbee563db3ae7ed224331f96b167e630d87ccebd",


### PR DESCRIPTION
## Purpose

As part of standardising Pact across OPG, a few changes:

- Use the latest version of the pact-verifier docker image rather than installing it locally
- Use GitHub Actions and its `repository_dispatch` event
- Add a Repository Trigger event to verify a specific Pact, for cross-org consistency

Part of [SP-1508](https://opgtransform.atlassian.net/browse/SP-1508)

## Approach

Previously, setting `LOCAL_URL` set the the DynamoDB host to `host.docker.internal` but that doesn't work when the Lambda is running inside Docker (in which case, the host should be `dynamodb`). To fix this, I've made `LOCAL_URL` a passthrough—which is how it's implied to work—and set its value as appropriate in docker/tests.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * I've updated the existing tests
* [x] The product team have tested these changes
  * N/A


[SP-1508]: https://opgtransform.atlassian.net/browse/SP-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ