### PR TITLE
upgrade to latest alpine images

### DIFF
--- a/lambda_functions/v1/Dockerfile-Dynamo
+++ b/lambda_functions/v1/Dockerfile-Dynamo
@@ -1,9 +1,10 @@
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-FROM python:3.10.7-alpine3.16 AS python-alpine
+FROM python:3.10.13-alpine3.18 AS python-alpine
 RUN apk add --no-cache \
-    libstdc++
+    libstdc++ \
+    elfutils-dev
 
 RUN apk update && apk upgrade expat
 
@@ -15,7 +16,6 @@ RUN apk add --no-cache \
     libtool \
     autoconf \
     automake \
-    libexecinfo-dev \
     make \
     cmake \
     libcurl

--- a/lambda_functions/v1/Dockerfile-Function
+++ b/lambda_functions/v1/Dockerfile-Function
@@ -1,9 +1,10 @@
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-FROM python:3.10.7-alpine3.16 AS python-alpine
+FROM python:3.10.13-alpine3.18 AS python-alpine
 RUN apk add --no-cache \
-    libstdc++
+    libstdc++ \
+    elfutils-dev
 
 RUN apk update && apk upgrade expat
 
@@ -15,7 +16,6 @@ RUN apk add --no-cache \
     libtool \
     autoconf \
     automake \
-    libexecinfo-dev \
     make \
     cmake \
     libcurl


### PR DESCRIPTION
Latest 3.10 alpine images.. Luckily I had already done the hard work on finding a replacement for libexecinfo-dev which is no longer available after alpine 3.16.