### PR TITLE
UML-3300 Adjust lpa IDs in test cases to better reflect common usage

### DIFF
--- a/lambda_functions/v1/tests/api/test_code_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_code_handler_cases.py
@@ -5,7 +5,7 @@ from pytest_cases import case
 
 default_test_data = [
     {
-        "lpa": "7000-0000-0047",
+        "lpa": "700000000047",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_1",
         "active": True,
@@ -16,7 +16,7 @@ default_test_data = [
         "status_details": "Generated",
     },
     {
-        "lpa": "7000-0000-0047",
+        "lpa": "700000000047",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_2",
         "active": True,

--- a/lambda_functions/v1/tests/api/test_code_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_code_handler_cases.py
@@ -5,7 +5,7 @@ from pytest_cases import case
 
 default_test_data = [
     {
-        "lpa": "eed4f597-fd87-4536-99d0-895778824861",
+        "lpa": "700000000047",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_1",
         "active": True,
@@ -16,7 +16,7 @@ default_test_data = [
         "status_details": "Generated",
     },
     {
-        "lpa": "eed4f597-fd87-4536-99d0-895778824861",
+        "lpa": "700000000047",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_2",
         "active": True,
@@ -27,7 +27,7 @@ default_test_data = [
         "status_details": "Generated",
     },
     {
-        "lpa": "productize_out_of_the_box_portals",
+        "lpa": "M-3AB4-1234-A812",
         "actor": "violet",
         "code": "code_3",
         "active": True,
@@ -38,7 +38,7 @@ default_test_data = [
         "status_details": "Generated",
     },
     {
-        "lpa": "productize_out_of_the_box_portals",
+        "lpa": "M-3AB4-1234-A812",
         "actor": "violet",
         "code": "code_4",
         "active": True,

--- a/lambda_functions/v1/tests/api/test_code_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_code_handler_cases.py
@@ -5,7 +5,7 @@ from pytest_cases import case
 
 default_test_data = [
     {
-        "lpa": "700000000047",
+        "lpa": "7000-0000-0047",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_1",
         "active": True,
@@ -16,7 +16,7 @@ default_test_data = [
         "status_details": "Generated",
     },
     {
-        "lpa": "700000000047",
+        "lpa": "7000-0000-0047",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_2",
         "active": True,

--- a/lambda_functions/v1/tests/api/test_create_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_create_handler_cases.py
@@ -5,7 +5,7 @@ from pytest_cases import case
 
 default_test_data = [
     {
-        "lpa": "eed4f597-fd87-4536-99d0-895778824861",
+        "lpa": "700000000092",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_1",
         "active": True,
@@ -16,7 +16,7 @@ default_test_data = [
         "status_details": "Generated",
     },
     {
-        "lpa": "eed4f597-fd87-4536-99d0-895778824861",
+        "lpa": "700000000092",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_2",
         "active": True,
@@ -27,7 +27,7 @@ default_test_data = [
         "status_details": "Generated",
     },
     {
-        "lpa": "productize_out_of_the_box_portals",
+        "lpa": "M-3AF4-1274-A81H",
         "actor": "violet",
         "code": "code_3",
         "active": True,
@@ -38,7 +38,7 @@ default_test_data = [
         "status_details": "Generated",
     },
     {
-        "lpa": "productize_out_of_the_box_portals",
+        "lpa": "M-3AF4-1274-A81H",
         "actor": "violet",
         "code": "code_4",
         "active": True,
@@ -58,7 +58,7 @@ def case_create_a_code_1():
     data = {
         "lpas": [
             {
-                "lpa": "eed4f597-fd87-4536-99d0-895778824861",
+                "lpa": "700000000092",
                 "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
                 "dob": "1960-06-05",
             }
@@ -70,7 +70,7 @@ def case_create_a_code_1():
     expected_result = {
         "codes": [
             {
-                "lpa": "eed4f597-fd87-4536-99d0-895778824861",
+                "lpa": "700000000092",
                 "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
                 "code": code,
             }
@@ -89,27 +89,27 @@ def case_create_a_code_2():
             {
                 "actor": "violet_1",
                 "dob": "1966-05-21",
-                "lpa": "productize_out_of_the_box_portals",
+                "lpa": "M-3AF4-1274-A81H",
             },
             {
                 "actor": "violet_2",
                 "dob": "1988-11-21",
-                "lpa": "productize_out_of_the_box_portals",
+                "lpa": "M-3AF4-1274-A81H",
             },
             {
                 "actor": "violet_3",
                 "dob": "1969-01-28",
-                "lpa": "productize_out_of_the_box_portals",
+                "lpa": "M-3AF4-1274-A81H",
             },
             {
                 "actor": "violet_4",
                 "dob": "1967-05-11",
-                "lpa": "productize_out_of_the_box_portals",
+                "lpa": "M-3AF4-1274-A81H",
             },
             {
                 "actor": "violet_5",
                 "dob": "1967-12-10",
-                "lpa": "productize_out_of_the_box_portals",
+                "lpa": "M-3AF4-1274-A81H",
             },
         ]
     }
@@ -121,27 +121,27 @@ def case_create_a_code_2():
             {
                 "actor": "violet_1",
                 "code": code,
-                "lpa": "productize_out_of_the_box_portals",
+                "lpa": "M-3AF4-1274-A81H",
             },
             {
                 "actor": "violet_2",
                 "code": code,
-                "lpa": "productize_out_of_the_box_portals",
+                "lpa": "M-3AF4-1274-A81H",
             },
             {
                 "actor": "violet_3",
                 "code": code,
-                "lpa": "productize_out_of_the_box_portals",
+                "lpa": "M-3AF4-1274-A81H",
             },
             {
                 "actor": "violet_4",
                 "code": code,
-                "lpa": "productize_out_of_the_box_portals",
+                "lpa": "M-3AF4-1274-A81H",
             },
             {
                 "actor": "violet_5",
                 "code": code,
-                "lpa": "productize_out_of_the_box_portals",
+                "lpa": "M-3AF4-1274-A81H",
             },
         ]
     }

--- a/lambda_functions/v1/tests/api/test_create_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_create_handler_cases.py
@@ -5,7 +5,7 @@ from pytest_cases import case
 
 default_test_data = [
     {
-        "lpa": "7000-0000-0092",
+        "lpa": "700000000092",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_1",
         "active": True,
@@ -16,7 +16,7 @@ default_test_data = [
         "status_details": "Generated",
     },
     {
-        "lpa": "7000-0000-0092",
+        "lpa": "700000000092",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_2",
         "active": True,
@@ -58,7 +58,7 @@ def case_create_a_code_1():
     data = {
         "lpas": [
             {
-                "lpa": "7000-0000-0092",
+                "lpa": "700000000092",
                 "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
                 "dob": "1960-06-05",
             }
@@ -70,7 +70,7 @@ def case_create_a_code_1():
     expected_result = {
         "codes": [
             {
-                "lpa": "7000-0000-0092",
+                "lpa": "700000000092",
                 "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
                 "code": code,
             }

--- a/lambda_functions/v1/tests/api/test_create_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_create_handler_cases.py
@@ -5,7 +5,7 @@ from pytest_cases import case
 
 default_test_data = [
     {
-        "lpa": "700000000092",
+        "lpa": "7000-0000-0092",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_1",
         "active": True,
@@ -16,7 +16,7 @@ default_test_data = [
         "status_details": "Generated",
     },
     {
-        "lpa": "700000000092",
+        "lpa": "7000-0000-0092",
         "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
         "code": "code_2",
         "active": True,
@@ -58,7 +58,7 @@ def case_create_a_code_1():
     data = {
         "lpas": [
             {
-                "lpa": "700000000092",
+                "lpa": "7000-0000-0092",
                 "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
                 "dob": "1960-06-05",
             }
@@ -70,7 +70,7 @@ def case_create_a_code_1():
     expected_result = {
         "codes": [
             {
-                "lpa": "700000000092",
+                "lpa": "7000-0000-0092",
                 "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
                 "code": code,
             }

--- a/lambda_functions/v1/tests/api/test_exists_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_exists_handler_cases.py
@@ -15,7 +15,7 @@ def case_actor_code_exists_1():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "7000-0000-0095",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Generated",
         },
@@ -26,7 +26,7 @@ def case_actor_code_exists_1():
             "dob": "1966-12-09",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "7000-0000-0095",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Superseded",
         },
@@ -37,7 +37,7 @@ def case_actor_code_exists_1():
             "dob": "1965-08-21",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "700000002196",
+            "lpa": "lpa_2",
             "generated_date": "2019-09-31",
             "status_details": "Generated",
         },
@@ -48,14 +48,14 @@ def case_actor_code_exists_1():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "7000-0000-0095",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "7000-0000-0095",
+        "lpa": "700000000095",
         "actor": "actor_1"
     }
 
@@ -77,7 +77,7 @@ def case_actor_code_exists_2():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "7000-0000-0095",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         },
@@ -88,14 +88,14 @@ def case_actor_code_exists_2():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "7000-0000-0095",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "7000-0000-0095",
+        "lpa": "700000000095",
         "actor": "actor_1"
     }
 
@@ -117,7 +117,7 @@ def case_actor_code_exists_3():
             "dob": "1966-12-09",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "7000-0000-0095",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Superseded",
         },
@@ -128,14 +128,14 @@ def case_actor_code_exists_3():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "7000-0000-0095",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "7000-0000-0095",
+        "lpa": "700000000095",
         "actor": "actor_1"
     }
 
@@ -157,7 +157,7 @@ def case_actor_code_exists_4():
             "dob": "1966-12-09",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "7000-0000-0095",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Superseded",
         },
@@ -168,14 +168,14 @@ def case_actor_code_exists_4():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "7000-0000-0095",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "7000-0000-0095",
+        "lpa": "700000000095",
         "actor": "actor_1"
     }
 

--- a/lambda_functions/v1/tests/api/test_exists_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_exists_handler_cases.py
@@ -15,7 +15,7 @@ def case_actor_code_exists_1():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "lpa_1",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Generated",
         },
@@ -26,7 +26,7 @@ def case_actor_code_exists_1():
             "dob": "1966-12-09",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "lpa_1",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Superseded",
         },
@@ -48,14 +48,14 @@ def case_actor_code_exists_1():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "lpa_1",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "lpa_1",
+        "lpa": "700000000095",
         "actor": "actor_1"
     }
 
@@ -77,7 +77,7 @@ def case_actor_code_exists_2():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "lpa_1",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         },
@@ -88,14 +88,14 @@ def case_actor_code_exists_2():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "lpa_1",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "lpa_1",
+        "lpa": "700000000095",
         "actor": "actor_1"
     }
 
@@ -117,7 +117,7 @@ def case_actor_code_exists_3():
             "dob": "1966-12-09",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "lpa_1",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Superseded",
         },
@@ -128,14 +128,14 @@ def case_actor_code_exists_3():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "lpa_1",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "lpa_1",
+        "lpa": "700000000095",
         "actor": "actor_1"
     }
 
@@ -157,7 +157,7 @@ def case_actor_code_exists_4():
             "dob": "1966-12-09",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "lpa_1",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Superseded",
         },
@@ -168,14 +168,14 @@ def case_actor_code_exists_4():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "lpa_1",
+            "lpa": "700000000095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "lpa_1",
+        "lpa": "700000000095",
         "actor": "actor_1"
     }
 

--- a/lambda_functions/v1/tests/api/test_exists_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_exists_handler_cases.py
@@ -37,7 +37,7 @@ def case_actor_code_exists_1():
             "dob": "1965-08-21",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "7000-0000-2196",
+            "lpa": "700000002196",
             "generated_date": "2019-09-31",
             "status_details": "Generated",
         },

--- a/lambda_functions/v1/tests/api/test_exists_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_exists_handler_cases.py
@@ -37,7 +37,7 @@ def case_actor_code_exists_1():
             "dob": "1965-08-21",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "700000002196",
+            "lpa": "7000-0000-2196",
             "generated_date": "2019-09-31",
             "status_details": "Generated",
         },

--- a/lambda_functions/v1/tests/api/test_exists_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_exists_handler_cases.py
@@ -15,7 +15,7 @@ def case_actor_code_exists_1():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "700000000095",
+            "lpa": "7000-0000-0095",
             "generated_date": "2019-09-31",
             "status_details": "Generated",
         },
@@ -26,7 +26,7 @@ def case_actor_code_exists_1():
             "dob": "1966-12-09",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "700000000095",
+            "lpa": "7000-0000-0095",
             "generated_date": "2019-09-31",
             "status_details": "Superseded",
         },
@@ -37,7 +37,7 @@ def case_actor_code_exists_1():
             "dob": "1965-08-21",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "lpa_2",
+            "lpa": "700000002196",
             "generated_date": "2019-09-31",
             "status_details": "Generated",
         },
@@ -48,14 +48,14 @@ def case_actor_code_exists_1():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "700000000095",
+            "lpa": "7000-0000-0095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "700000000095",
+        "lpa": "7000-0000-0095",
         "actor": "actor_1"
     }
 
@@ -77,7 +77,7 @@ def case_actor_code_exists_2():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "700000000095",
+            "lpa": "7000-0000-0095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         },
@@ -88,14 +88,14 @@ def case_actor_code_exists_2():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "700000000095",
+            "lpa": "7000-0000-0095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "700000000095",
+        "lpa": "7000-0000-0095",
         "actor": "actor_1"
     }
 
@@ -117,7 +117,7 @@ def case_actor_code_exists_3():
             "dob": "1966-12-09",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "700000000095",
+            "lpa": "7000-0000-0095",
             "generated_date": "2019-09-31",
             "status_details": "Superseded",
         },
@@ -128,14 +128,14 @@ def case_actor_code_exists_3():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "700000000095",
+            "lpa": "7000-0000-0095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "700000000095",
+        "lpa": "7000-0000-0095",
         "actor": "actor_1"
     }
 
@@ -157,7 +157,7 @@ def case_actor_code_exists_4():
             "dob": "1966-12-09",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "700000000095",
+            "lpa": "7000-0000-0095",
             "generated_date": "2019-09-31",
             "status_details": "Superseded",
         },
@@ -168,14 +168,14 @@ def case_actor_code_exists_4():
             "dob": "1960-06-05",
             "expiry_date": test_constants["EXPIRY_DATE"],
             "last_updated_date": "2019-12-26",
-            "lpa": "700000000095",
+            "lpa": "7000-0000-0095",
             "generated_date": "2019-09-31",
             "status_details": "Revoked",
         }
     ]
 
     data = {
-        "lpa": "700000000095",
+        "lpa": "7000-0000-0095",
         "actor": "actor_1"
     }
 

--- a/lambda_functions/v1/tests/api/test_revoke_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_revoke_handler_cases.py
@@ -16,7 +16,7 @@ def case_revoke_a_code_1():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "mesh_end_to_end_systems",
+            "lpa": "700000000096",
             "status_details": "Generated",
         }
     ]
@@ -48,7 +48,7 @@ def case_revoke_a_code_2():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "mesh_end_to_end_systems",
+            "lpa": "700000000096",
             "status_details": "Superseded",
         }
     ]
@@ -80,7 +80,7 @@ def case_revoke_a_code_3():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "mesh_end_to_end_systems",
+            "lpa": "700000000096",
             "status_details": "Revoked",
         }
     ]

--- a/lambda_functions/v1/tests/api/test_revoke_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_revoke_handler_cases.py
@@ -16,7 +16,7 @@ def case_revoke_a_code_1():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "700000000096",
+            "lpa": "7000-0000-0096",
             "status_details": "Generated",
         }
     ]
@@ -48,7 +48,7 @@ def case_revoke_a_code_2():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "700000000096",
+            "lpa": "7000-0000-0096",
             "status_details": "Superseded",
         }
     ]
@@ -80,7 +80,7 @@ def case_revoke_a_code_3():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "700000000096",
+            "lpa": "7000-0000-0096",
             "status_details": "Revoked",
         }
     ]

--- a/lambda_functions/v1/tests/api/test_revoke_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_revoke_handler_cases.py
@@ -16,7 +16,7 @@ def case_revoke_a_code_1():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "7000-0000-0096",
+            "lpa": "700000000096",
             "status_details": "Generated",
         }
     ]
@@ -48,7 +48,7 @@ def case_revoke_a_code_2():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "7000-0000-0096",
+            "lpa": "700000000096",
             "status_details": "Superseded",
         }
     ]
@@ -80,7 +80,7 @@ def case_revoke_a_code_3():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "7000-0000-0096",
+            "lpa": "700000000096",
             "status_details": "Revoked",
         }
     ]

--- a/lambda_functions/v1/tests/api/test_validate_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_validate_handler_cases.py
@@ -12,12 +12,12 @@ def case_validate_valid_code_1():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "scale_virtual_e_commerce",
+            "lpa": "M-3AC4-1274-AP1H",
         }
     ]
 
     data = {
-        "lpa": "scale_virtual_e_commerce",
+        "lpa": "M-3AC4-1274-AP1H",
         "dob": "1960-06-05",
         "code": "t39hg7zQdE59",
     }
@@ -38,12 +38,12 @@ def case_validate_valid_code_2():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "scale_virtual_e_commerce",
+            "lpa": "M-3AC4-1274-AP1H",
         }
     ]
 
     data = {
-        "lpa": "scale_virtual_e_commerce",
+        "lpa": "M-3AC4-1274-AP1H",
         "dob": "1960-06-05",
         "code": "t39hg7zQdE59",
     }
@@ -64,7 +64,7 @@ def case_validate_non_existent_code():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "scale_virtual_e_commerce",
+            "lpa": "M-3AC4-1274-AP1H",
         }
     ]
 
@@ -90,12 +90,12 @@ def case_validate_invalid_code_1():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "scale_virtual_e_commerce",
+            "lpa": "M-3AC4-1274-AP1H",
         }
     ]
 
     data = {
-        "lpa": "scale_virtual_e_commerce",
+        "lpa": "M-3AC4-1274-AP1H",
         "dob": "1960-06-15",
         "code": "t39hg7zQdE59",
     }
@@ -116,7 +116,7 @@ def case_validate_invalid_code_2():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "scale_virtual_e_commerce",
+            "lpa": "M-3AC4-1274-AP1H",
         }
     ]
 
@@ -138,12 +138,12 @@ def case_validate_valid_code_3():
             "generated_date": "2019-09-31",
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
-            "lpa": "scale_virtual_e_commerce",
+            "lpa": "M-3AC4-1274-AP1H",
         }
     ]
 
     data = {
-        "lpa": "scale_virtual_e_commerce",
+        "lpa": "M-3AC4-1274-AP1H",
         "dob": "1960-06-05",
         "code": "t39hg7zQdE59",
     }

--- a/lambda_functions/v1/tests/code_generator/test_check_code_unique_cases.py
+++ b/lambda_functions/v1/tests/code_generator/test_check_code_unique_cases.py
@@ -10,7 +10,7 @@ default_test_data = [
         "generated_date": "22/07/2019",
         "last_updated_date": "11/09/2019",
         "dob": "1960-06-05",
-        "lpa": "maximize_best_of_breed_synergies",
+        "lpa": "M-12CD-1234-CB12",
     },
     {
         "active": True,
@@ -20,7 +20,7 @@ default_test_data = [
         "generated_date": "18/11/2019",
         "last_updated_date": "23/05/2020",
         "dob": "1960-06-05",
-        "lpa": "maximize_best_of_breed_synergies",
+        "lpa": "M-12CD-1234-CB12",
     },
     {
         "active": True,
@@ -30,7 +30,7 @@ default_test_data = [
         "generated_date": "10/09/2019",
         "last_updated_date": "22/11/2019",
         "dob": "1960-06-05",
-        "lpa": "maximize_best_of_breed_synergies",
+        "lpa": "M-ABCD-1234-AB12",
     },
     {
         "active": False,
@@ -40,7 +40,7 @@ default_test_data = [
         "generated_date": "25/08/2019",
         "last_updated_date": "18/08/2020",
         "dob": "1960-06-05",
-        "lpa": "maximize_best_of_breed_synergies",
+        "lpa": "M-12CD-1234-CB12",
     },
 ]
 

--- a/lambda_functions/v1/tests/code_generator/test_get_codes_cases.py
+++ b/lambda_functions/v1/tests/code_generator/test_get_codes_cases.py
@@ -13,7 +13,7 @@ default_test_data = [
         "generated_date": "29/03/2020",
         "last_updated_date": "25/08/2020",
         "dob": "1960-06-05",
-        "lpa": "700000000138",
+        "lpa": "7000-0000-0138",
     },
     {
         "active": True,
@@ -23,7 +23,7 @@ default_test_data = [
         "generated_date": "27/06/2019",
         "last_updated_date": "03/02/2020",
         "dob": "1960-06-05",
-        "lpa": "700000000138",
+        "lpa": "7000-0000-0138",
     },
     {
         "active": True,
@@ -33,7 +33,7 @@ default_test_data = [
         "generated_date": "05/04/2020",
         "last_updated_date": "28/02/2021",
         "dob": "1960-06-05",
-        "lpa": "700000000138",
+        "lpa": "7000-0000-0138",
     },
     {
         "active": False,
@@ -43,7 +43,7 @@ default_test_data = [
         "generated_date": "07/08/2019",
         "last_updated_date": "24/03/2020",
         "dob": "1960-06-05",
-        "lpa": "700000000138",
+        "lpa": "7000-0000-0138",
     },
     {
         "active": False,
@@ -53,7 +53,7 @@ default_test_data = [
         "generated_date": "06/08/2019",
         "last_updated_date": "01/12/2019",
         "dob": "1960-06-05",
-        "lpa": "700000000138",
+        "lpa": "7000-0000-0138",
     },
     {
         "active": False,
@@ -63,7 +63,7 @@ default_test_data = [
         "generated_date": "03/01/2020",
         "last_updated_date": "11/04/2020",
         "dob": "1960-06-05",
-        "lpa": "700000000138",
+        "lpa": "7000-0000-0138",
     },
     {
         "active": False,
@@ -73,7 +73,7 @@ default_test_data = [
         "generated_date": "09/03/2020",
         "last_updated_date": "17/10/2020",
         "dob": "1960-06-05",
-        "lpa": "700000000138",
+        "lpa": "7000-0000-0138",
     },
 ]
 
@@ -83,7 +83,7 @@ def case_get_codes_1():
     test_data = deepcopy(default_test_data)
     code = None
     key = {
-        "lpa": "700000000138",
+        "lpa": "7000-0000-0138",
         "actor": "mediumblue",
     }
 
@@ -149,7 +149,7 @@ def case_get_codes_11_in233_1():
     test_data = deepcopy(default_test_data)
     code = None
     key = {
-        "lpa": "700000000138",
+        "lpa": "7000-0000-0138",
         "actor": "fake_actor",
     }
 
@@ -215,7 +215,7 @@ def case_get_codes_3():
     test_data = deepcopy(default_test_data)
     code = "ZY577rXcRVLY"
     key = {
-        "lpa": "700000000138",
+        "lpa": "7000-0000-0138",
         "actor": "mediumblue",
     }
 
@@ -250,12 +250,12 @@ def case_get_codes_13():
             "generated_date": "2019-05-25",
             "last_updated_date": "2019-05-25",
             "dob": "1960-06-05",
-            "lpa": "700000000138",
+            "lpa": "7000-0000-0138",
         },
     ]
     code = None
     key = {
-        "lpa": "700000000138",
+        "lpa": "7000-0000-0138",
         "actor": "mediumblue",
     }
 
@@ -289,7 +289,7 @@ def case_get_codes_12():
             "generated_date": "2019-05-25",
             "last_updated_date": "2019-05-25",
             "dob": "1960-06-05",
-            "lpa": "700000000138",
+            "lpa": "7000-0000-0138",
         },
     ]
     code = "YsSu4iAztUXm"

--- a/lambda_functions/v1/tests/code_generator/test_get_codes_cases.py
+++ b/lambda_functions/v1/tests/code_generator/test_get_codes_cases.py
@@ -13,7 +13,7 @@ default_test_data = [
         "generated_date": "29/03/2020",
         "last_updated_date": "25/08/2020",
         "dob": "1960-06-05",
-        "lpa": "7000-0000-0138",
+        "lpa": "700000000138",
     },
     {
         "active": True,
@@ -23,7 +23,7 @@ default_test_data = [
         "generated_date": "27/06/2019",
         "last_updated_date": "03/02/2020",
         "dob": "1960-06-05",
-        "lpa": "7000-0000-0138",
+        "lpa": "700000000138",
     },
     {
         "active": True,
@@ -33,7 +33,7 @@ default_test_data = [
         "generated_date": "05/04/2020",
         "last_updated_date": "28/02/2021",
         "dob": "1960-06-05",
-        "lpa": "7000-0000-0138",
+        "lpa": "700000000138",
     },
     {
         "active": False,
@@ -43,7 +43,7 @@ default_test_data = [
         "generated_date": "07/08/2019",
         "last_updated_date": "24/03/2020",
         "dob": "1960-06-05",
-        "lpa": "7000-0000-0138",
+        "lpa": "700000000138",
     },
     {
         "active": False,
@@ -53,7 +53,7 @@ default_test_data = [
         "generated_date": "06/08/2019",
         "last_updated_date": "01/12/2019",
         "dob": "1960-06-05",
-        "lpa": "7000-0000-0138",
+        "lpa": "700000000138",
     },
     {
         "active": False,
@@ -63,7 +63,7 @@ default_test_data = [
         "generated_date": "03/01/2020",
         "last_updated_date": "11/04/2020",
         "dob": "1960-06-05",
-        "lpa": "7000-0000-0138",
+        "lpa": "700000000138",
     },
     {
         "active": False,
@@ -73,7 +73,7 @@ default_test_data = [
         "generated_date": "09/03/2020",
         "last_updated_date": "17/10/2020",
         "dob": "1960-06-05",
-        "lpa": "7000-0000-0138",
+        "lpa": "700000000138",
     },
 ]
 
@@ -83,7 +83,7 @@ def case_get_codes_1():
     test_data = deepcopy(default_test_data)
     code = None
     key = {
-        "lpa": "7000-0000-0138",
+        "lpa": "700000000138",
         "actor": "mediumblue",
     }
 
@@ -149,7 +149,7 @@ def case_get_codes_11_in233_1():
     test_data = deepcopy(default_test_data)
     code = None
     key = {
-        "lpa": "7000-0000-0138",
+        "lpa": "700000000138",
         "actor": "fake_actor",
     }
 
@@ -215,7 +215,7 @@ def case_get_codes_3():
     test_data = deepcopy(default_test_data)
     code = "ZY577rXcRVLY"
     key = {
-        "lpa": "7000-0000-0138",
+        "lpa": "700000000138",
         "actor": "mediumblue",
     }
 
@@ -250,12 +250,12 @@ def case_get_codes_13():
             "generated_date": "2019-05-25",
             "last_updated_date": "2019-05-25",
             "dob": "1960-06-05",
-            "lpa": "7000-0000-0138",
+            "lpa": "700000000138",
         },
     ]
     code = None
     key = {
-        "lpa": "7000-0000-0138",
+        "lpa": "700000000138",
         "actor": "mediumblue",
     }
 
@@ -289,7 +289,7 @@ def case_get_codes_12():
             "generated_date": "2019-05-25",
             "last_updated_date": "2019-05-25",
             "dob": "1960-06-05",
-            "lpa": "7000-0000-0138",
+            "lpa": "700000000138",
         },
     ]
     code = "YsSu4iAztUXm"

--- a/lambda_functions/v1/tests/code_generator/test_get_codes_cases.py
+++ b/lambda_functions/v1/tests/code_generator/test_get_codes_cases.py
@@ -13,7 +13,7 @@ default_test_data = [
         "generated_date": "29/03/2020",
         "last_updated_date": "25/08/2020",
         "dob": "1960-06-05",
-        "lpa": "drive_leading-edge_communities",
+        "lpa": "700000000138",
     },
     {
         "active": True,
@@ -23,7 +23,7 @@ default_test_data = [
         "generated_date": "27/06/2019",
         "last_updated_date": "03/02/2020",
         "dob": "1960-06-05",
-        "lpa": "drive_leading-edge_communities",
+        "lpa": "700000000138",
     },
     {
         "active": True,
@@ -33,7 +33,7 @@ default_test_data = [
         "generated_date": "05/04/2020",
         "last_updated_date": "28/02/2021",
         "dob": "1960-06-05",
-        "lpa": "drive_leading-edge_communities",
+        "lpa": "700000000138",
     },
     {
         "active": False,
@@ -43,7 +43,7 @@ default_test_data = [
         "generated_date": "07/08/2019",
         "last_updated_date": "24/03/2020",
         "dob": "1960-06-05",
-        "lpa": "drive_leading-edge_communities",
+        "lpa": "700000000138",
     },
     {
         "active": False,
@@ -53,7 +53,7 @@ default_test_data = [
         "generated_date": "06/08/2019",
         "last_updated_date": "01/12/2019",
         "dob": "1960-06-05",
-        "lpa": "drive_leading-edge_communities",
+        "lpa": "700000000138",
     },
     {
         "active": False,
@@ -63,7 +63,7 @@ default_test_data = [
         "generated_date": "03/01/2020",
         "last_updated_date": "11/04/2020",
         "dob": "1960-06-05",
-        "lpa": "drive_leading-edge_communities",
+        "lpa": "700000000138",
     },
     {
         "active": False,
@@ -73,7 +73,7 @@ default_test_data = [
         "generated_date": "09/03/2020",
         "last_updated_date": "17/10/2020",
         "dob": "1960-06-05",
-        "lpa": "drive_leading-edge_communities",
+        "lpa": "700000000138",
     },
 ]
 
@@ -83,7 +83,7 @@ def case_get_codes_1():
     test_data = deepcopy(default_test_data)
     code = None
     key = {
-        "lpa": "drive_leading-edge_communities",
+        "lpa": "700000000138",
         "actor": "mediumblue",
     }
 
@@ -149,7 +149,7 @@ def case_get_codes_11_in233_1():
     test_data = deepcopy(default_test_data)
     code = None
     key = {
-        "lpa": "drive_leading-edge_communities",
+        "lpa": "700000000138",
         "actor": "fake_actor",
     }
 
@@ -215,7 +215,7 @@ def case_get_codes_3():
     test_data = deepcopy(default_test_data)
     code = "ZY577rXcRVLY"
     key = {
-        "lpa": "drive_leading-edge_communities",
+        "lpa": "700000000138",
         "actor": "mediumblue",
     }
 
@@ -250,12 +250,12 @@ def case_get_codes_13():
             "generated_date": "2019-05-25",
             "last_updated_date": "2019-05-25",
             "dob": "1960-06-05",
-            "lpa": "drive_leading-edge_communities",
+            "lpa": "700000000138",
         },
     ]
     code = None
     key = {
-        "lpa": "drive_leading-edge_communities",
+        "lpa": "700000000138",
         "actor": "mediumblue",
     }
 
@@ -289,7 +289,7 @@ def case_get_codes_12():
             "generated_date": "2019-05-25",
             "last_updated_date": "2019-05-25",
             "dob": "1960-06-05",
-            "lpa": "drive_leading-edge_communities",
+            "lpa": "700000000138",
         },
     ]
     code = "YsSu4iAztUXm"


### PR DESCRIPTION
## Purpose

_The lpa ids in the test cases do not currently resemble closely what lpa ids are in practice. Fix this_

## Approach

_Change test case data to use lpa ids that are closer to legacy and modernise lpa ids rather than just random strings. Note that it IS intentional here that the legacy style 7000 IDs do not have dashes in them, but the Modernise M-1234- do have dashes_


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
