### PR TITLE
UML-3238 mark_used endpoint to set expiry for Modernise codes

### DIFF
--- a/lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py
@@ -101,13 +101,16 @@ def get_codes(database, key=None, code=None):
         )
 
         try:
-            expiry_date = query_result["Item"]["expiry_date"]
+            if "expiry_date" in query_result["Item"] :
+                expiry_date = query_result["Item"]["expiry_date"]
 
-            if expiry_date > ttl_cutoff:
-                query_result["Item"]["expiry_date"] = int(expiry_date)
-                codes.append(query_result["Item"])
+                if expiry_date > ttl_cutoff:
+                    query_result["Item"]["expiry_date"] = int(expiry_date)
+                    codes.append(query_result["Item"])
+                else:
+                    logger.info("Code does not exist in database")
             else:
-                logger.info("Code does not exist in database")
+                codes.append(query_result["Item"])
         except KeyError:
             # TODO better error handling here
             logger.info("Code does not exist in database")

--- a/lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py
@@ -26,7 +26,7 @@ def generate_code(database):
     attempts = 0
     max_attempts = 10
 
-    while unique is not True:
+    while not unique:
         new_code = "".join(secrets.choice(acceptable_characters) for i in range(0, 12))
         unique = check_code_unique(database=database, code=new_code)
         attempts += 1

--- a/lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py
@@ -222,7 +222,7 @@ def insert_new_code(database, key, dob, code):
             "generated_date": date_formatter(datetime.datetime.now()),
             "status_details": "Generated",
         }
-    if lpa[0] != 'M' : 
+    if lpa[0] not in ('M' , 'm') :
         item.update({"expiry_date" : calculate_expiry_date(today=datetime.datetime.now())})
     table.put_item(
         Item=item

--- a/lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py
@@ -137,7 +137,7 @@ def get_codes(database, key=None, code=None):
     return codes
 
 
-def update_codes(database, key=None, code=None, status=False, status_details=None):
+def update_codes(database, key=None, code=None, status=False, status_details=None, expiry_date=None):
     """
     Generic method to update the status of rows in the db, eithet by key (lpa/actor)
     or code.
@@ -148,6 +148,7 @@ def update_codes(database, key=None, code=None, status=False, status_details=Non
         code: string
         status: boolean
         status_details: string
+        expiry_date: string
 
     Returns:
         int: number of rows updated
@@ -164,17 +165,28 @@ def update_codes(database, key=None, code=None, status=False, status_details=Non
     updated_rows = 0
     for entry in entries:
         if entry["active"] != status:
-
-            table.update_item(
-                Key={"code": entry["code"]},
-                UpdateExpression="set active = :a, last_updated_date = :d, "
-                "status_details = :s",
-                ExpressionAttributeValues={
-                    ":a": status,
-                    ":d": date_formatter(datetime.datetime.now()),
-                    ":s": status_details,
-                },
-            )
+            if expiry_date:
+                table.update_item(
+                    Key={"code": entry["code"]},
+                    UpdateExpression="set active = :a, last_updated_date = :d, "
+                    "expiry_date = :e",
+                    ExpressionAttributeValues={
+                        ":a": status,
+                        ":d": date_formatter(datetime.datetime.now()),
+                        ":e": expiry_date,
+                    },
+                )
+            else:
+                table.update_item(
+                    Key={"code": entry["code"]},
+                    UpdateExpression="set active = :a, last_updated_date = :d, "
+                    "status_details = :s",
+                    ExpressionAttributeValues={
+                        ":a": status,
+                        ":d": date_formatter(datetime.datetime.now()),
+                        ":s": status_details,
+                    },
+                )
 
             updated_rows += 1
     logger.info(f"{updated_rows} rows updated for LPA/Actor")

--- a/lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py
@@ -212,8 +212,7 @@ def insert_new_code(database, key, dob, code):
     lpa = key["lpa"]
     actor = key["actor"]
 
-    table.put_item(
-        Item={
+    item={
             "lpa": lpa,
             "actor": actor,
             "code": code,
@@ -221,9 +220,12 @@ def insert_new_code(database, key, dob, code):
             "last_updated_date": date_formatter(datetime.datetime.now()),
             "dob": dob,
             "generated_date": date_formatter(datetime.datetime.now()),
-            "expiry_date": calculate_expiry_date(today=datetime.datetime.now()),
             "status_details": "Generated",
         }
+    if lpa[0] != 'M' : 
+        item.update({"expiry_date" : calculate_expiry_date(today=datetime.datetime.now())})
+    table.put_item(
+        Item=item
     )
 
     inserted_item = get_codes(database, code=code)

--- a/lambda_functions/v1/functions/lpa_codes/app/api/endpoints.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/endpoints.py
@@ -1,6 +1,7 @@
 from . import code_generator
 from .database import db_connection
 from .helpers import custom_logger, calculate_expiry_date
+import datetime
 
 
 logger = custom_logger()

--- a/lambda_functions/v1/functions/lpa_codes/app/api/endpoints.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/endpoints.py
@@ -1,6 +1,6 @@
 from . import code_generator
 from .database import db_connection
-from .helpers import custom_logger
+from .helpers import custom_logger, calculate_expiry_date
 
 
 logger = custom_logger()
@@ -137,6 +137,41 @@ def handle_revoke(data):
 
     return {"codes revoked": update_result}, 200
 
+
+def handle_mark_used(data):
+    """
+    Updates sets the expiry_date of the provided code to 2 years from now
+    Returns the number of codes marked used - 
+
+    Args:
+        data: dict of payload data
+
+    Example args:
+        {
+          "code": "YsSu4iAztUXm"
+        }
+
+    Returns:
+        tuple: (number of codes marked used, http status code)
+
+    Example return:
+        (
+            {"codes marked used": 1},
+            200
+        )
+
+    """
+    db = db_connection()
+
+    try:
+        update_result = code_generator.update_codes(
+            database=db, code=data["code"], expiry_date=calculate_expiry_date(months = 24, today=datetime.datetime.now())
+        )
+    except Exception as e:
+        logger.error(f"Error in handle_mark_used > update_codes: {e}")
+        return None, 500
+
+    return {"codes marked used": update_result}, 200
 
 def handle_validate(data):
     """

--- a/lambda_functions/v1/functions/lpa_codes/app/api/resources.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/resources.py
@@ -100,6 +100,33 @@ def revoke_route():
 
     return jsonify(result), status_code
 
+@api.route("/mark_used", methods=["POST"])
+def mark_used_route():
+    """
+    Marks the given code as used (sets the expiry date)
+
+    Payload *should* be validated by API-Gateway before it gets here, but as it causes
+    everything to explode if a required field is missing we are checking here also.
+
+    Returns:
+        if payload is valid - dict of the posted data, status code
+        if payload is invalid - 400
+    """
+    post_data = request.get_json()
+
+    try:
+        code = post_data["code"]
+    except KeyError as e:
+        logger.debug(f"Missing param from request: {e}")
+        return abort(400)
+
+    if code == "":
+        logger.debug(f"Empty param in request: code")
+        return abort(400)
+
+    result, status_code = endpoints.handle_mark_used(data=post_data)
+
+    return jsonify(result), status_code
 
 @api.route("/validate", methods=["POST"])
 def validate_route():

--- a/lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml
+++ b/lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml
@@ -386,6 +386,85 @@ paths:
             application/vnd.opg-data.v1+json:
               schema:
                 $ref: '#/components/schemas/Error503'
+  /mark_used:
+    post:
+      summary: "Mark a Modernise code as used - set the expiry date from now"
+      description: "Mark a Modernise code as used - set the expiry date from nowe"
+      operationId: api.resources.mark_used_route
+      security:
+        - sigv4: []
+      x-amazon-apigateway-request-validator: "all"
+      x-amazon-apigateway-integration:
+        uri: arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${region}:${account_id}:function:$${stageVariables.lpa_codes_function_name}/invocations
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        httpMethod: "POST"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws_proxy"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+              example:
+                code: "YsSu4iAztUXm"
+      responses:
+        200:
+          description: OK
+        400:
+          description: Generic bad request (generally invalid syntax)
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        401:
+          description: Unauthorised (no current user and there should be)
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: Forbidden - The current user is forbidden from accessing this data (in this way)
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        404:
+          description: That URL is not a valid route, or the item resource does not exist
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error404'
+        413:
+          description: Payload too large
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error413'
+        415:
+          description: Unsupported media type
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error415'
+        500:
+          description: Something unexpected happened and it is the API"s fault
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+        503:
+          description: Service Unavailable - please try again later
+          content:
+            application/vnd.opg-data.v1+json:
+              schema:
+                $ref: '#/components/schemas/Error503'
   /exists:
     post:
       summary: "Checks if a code exists for a specific actor on an LPA"

--- a/lambda_functions/v1/tests/api/test_create_handler.py
+++ b/lambda_functions/v1/tests/api/test_create_handler.py
@@ -70,7 +70,10 @@ def test_data(mock_database, mock_generate_code, test_data, data, expected_resul
                     assert item["status_details"] == "Generated"
                     assert item["last_updated_date"] == test_constants["TODAY_ISO"]
                     assert item["generated_date"] == test_constants["TODAY_ISO"]
-                    assert item["expiry_date"] == test_constants["EXPIRY_DATE"]
+                    if lpa[0] in ('M' , 'm') :
+                        assert ('expiry_date' not in item)
+                    else:
+                        assert item["expiry_date"] == test_constants["EXPIRY_DATE"]
                 else:
                     assert item["active"] is False
                     assert item["status_details"] == "Superseded"

--- a/lambda_functions/v1/tests/api/test_create_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_create_handler_cases.py
@@ -80,6 +80,34 @@ def case_create_a_code_1():
     return test_data, data, expected_result, expected_status_code
 
 
+@case(id="Create a single Modernise code")
+def case_create_a_modernise_code():
+    test_data = copy.deepcopy(default_test_data)
+
+    data = {
+        "lpas": [
+            {
+                "lpa": "M-3AF4-1274-A81H",
+                "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
+                "dob": "1960-06-05",
+            }
+        ]
+    }
+
+    code = test_constants["DEFAULT_CODE"]
+
+    expected_result = {
+        "codes": [
+            {
+                "lpa": "M-3AF4-1274-A81H",
+                "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
+                "code": code,
+            }
+        ]
+    }
+    expected_status_code = 200
+    return test_data, data, expected_result, expected_status_code
+
 @case(id="Create multiple codes")
 def case_create_a_code_2():
     test_data = copy.deepcopy(default_test_data)

--- a/lambda_functions/v1/tests/api/test_mark_used_handler.py
+++ b/lambda_functions/v1/tests/api/test_mark_used_handler.py
@@ -3,6 +3,7 @@ import datetime
 import boto3
 import pytz
 from boto3.dynamodb.conditions import Key
+from decimal import Decimal
 
 from lambda_functions.v1.functions.lpa_codes.app.api import code_generator
 from lambda_functions.v1.functions.lpa_codes.app.api.database import lpa_codes_table

--- a/lambda_functions/v1/tests/api/test_mark_used_handler.py
+++ b/lambda_functions/v1/tests/api/test_mark_used_handler.py
@@ -1,16 +1,27 @@
 import logging
 import datetime
 import boto3
+import pytz
 from boto3.dynamodb.conditions import Key
 
 from lambda_functions.v1.functions.lpa_codes.app.api import code_generator
 from lambda_functions.v1.functions.lpa_codes.app.api.database import lpa_codes_table
-from lambda_functions.v1.functions.lpa_codes.app.api.endpoints import handle_revoke
+from lambda_functions.v1.functions.lpa_codes.app.api.endpoints import handle_mark_used
 from pytest_cases import parametrize_with_cases
 
 from lambda_functions.v1.tests.conftest import insert_test_data, remove_test_data
 from freezegun import freeze_time
 
+def two_years_from_now():
+    tz = pytz.utc
+    today = datetime.datetime.now(tz=tz).date()
+    two_years_from_now = datetime.datetime.combine(
+        today.replace(year=today.year + 2), datetime.time.min, tzinfo=tz
+    )
+
+    two_years_from_now_decimal = Decimal(two_years_from_now.strftime("%s"))
+
+    return two_years_from_now_decimal
 
 @parametrize_with_cases("test_data, data, expected_result, expected_last_updated_date, expected_status_code")
 @freeze_time(datetime.date.today())
@@ -24,18 +35,18 @@ def test_post(mock_database,
     # Set up test data
     insert_test_data(test_data=test_data)
 
-    # Perform revoke & check return
-    result, status_code = handle_revoke(data=data)
+    # Perform mark_used & check return
+    result, status_code = handle_mark_used(data=data)
     assert result == expected_result
     assert status_code == expected_status_code
 
-    # Check the data after revoke has been performed
+    # Check the data after mark_used has been performed
     db = boto3.resource("dynamodb")
-    after_revoke = code_generator.get_codes(database=db, code=data["code"])
+    after_mark_used = code_generator.get_codes(database=db, code=data["code"])
 
-    if after_revoke:
-        lpa = after_revoke[0]["lpa"]
-        actor = after_revoke[0]["actor"]
+    if after_mark_used:
+        lpa = after_mark_used[0]["lpa"]
+        actor = after_mark_used[0]["actor"]
 
         db = boto3.resource("dynamodb")
         table = db.Table(lpa_codes_table())
@@ -49,10 +60,7 @@ def test_post(mock_database,
 
         if data["code"] == row_data["code"]:
             assert row_data["last_updated_date"] == expected_last_updated_date
-            assert row_data["status_details"] in [
-                "Revoked",
-                "Superseded",
-            ]
+            assert row_data["expiry_date"] == two_years_from_now()
             assert row_data["active"] is False
 
     remove_test_data(test_data)
@@ -71,7 +79,7 @@ def test_get_codes_broken(
     expected_status_code,
 ):
 
-    result, status_code = handle_revoke(data=data)
+    result, status_code = handle_mark_used(data=data)
 
     assert status_code == 500
     with caplog.at_level(logging.ERROR):

--- a/lambda_functions/v1/tests/api/test_mark_used_handler.py
+++ b/lambda_functions/v1/tests/api/test_mark_used_handler.py
@@ -24,7 +24,7 @@ def two_years_from_now():
 
     return two_years_from_now_decimal
 
-@parametrize_with_cases("test_data, data, expected_result, expected_last_updated_date, expected_status_code")
+@parametrize_with_cases("test_data, data, expected_result, expected_last_updated_date, expected_status_code, expected_expiry_date")
 @freeze_time(datetime.date.today())
 def test_post(mock_database, 
     test_data,
@@ -32,6 +32,7 @@ def test_post(mock_database,
     expected_result,
     expected_last_updated_date,
     expected_status_code,
+    expected_expiry_date
 ):
     # Set up test data
     insert_test_data(test_data=test_data)
@@ -67,7 +68,7 @@ def test_post(mock_database,
     remove_test_data(test_data)
 
 
-@parametrize_with_cases("test_data, data, expected_result, expected_last_updated_date,expected_status_code")
+@parametrize_with_cases("test_data, data, expected_result, expected_last_updated_date, expected_status_code, expected_expiry_date")
 def test_get_codes_broken(
     mock_database,
     mock_generate_code,
@@ -78,6 +79,7 @@ def test_get_codes_broken(
     expected_result,
     expected_last_updated_date,
     expected_status_code,
+    expected_expiry_date
 ):
 
     result, status_code = handle_mark_used(data=data)

--- a/lambda_functions/v1/tests/api/test_mark_used_handler.py
+++ b/lambda_functions/v1/tests/api/test_mark_used_handler.py
@@ -1,0 +1,78 @@
+import logging
+import datetime
+import boto3
+from boto3.dynamodb.conditions import Key
+
+from lambda_functions.v1.functions.lpa_codes.app.api import code_generator
+from lambda_functions.v1.functions.lpa_codes.app.api.database import lpa_codes_table
+from lambda_functions.v1.functions.lpa_codes.app.api.endpoints import handle_revoke
+from pytest_cases import parametrize_with_cases
+
+from lambda_functions.v1.tests.conftest import insert_test_data, remove_test_data
+from freezegun import freeze_time
+
+
+@parametrize_with_cases("test_data, data, expected_result, expected_last_updated_date, expected_status_code")
+@freeze_time(datetime.date.today())
+def test_post(mock_database, 
+    test_data,
+    data,
+    expected_result,
+    expected_last_updated_date,
+    expected_status_code,
+):
+    # Set up test data
+    insert_test_data(test_data=test_data)
+
+    # Perform revoke & check return
+    result, status_code = handle_revoke(data=data)
+    assert result == expected_result
+    assert status_code == expected_status_code
+
+    # Check the data after revoke has been performed
+    db = boto3.resource("dynamodb")
+    after_revoke = code_generator.get_codes(database=db, code=data["code"])
+
+    if after_revoke:
+        lpa = after_revoke[0]["lpa"]
+        actor = after_revoke[0]["actor"]
+
+        db = boto3.resource("dynamodb")
+        table = db.Table(lpa_codes_table())
+
+        query_result = table.query(
+            IndexName="key_index",
+            KeyConditionExpression=Key("lpa").eq(lpa) & Key("actor").eq(actor),
+        )
+
+        row_data = query_result["Items"][0]
+
+        if data["code"] == row_data["code"]:
+            assert row_data["last_updated_date"] == expected_last_updated_date
+            assert row_data["status_details"] in [
+                "Revoked",
+                "Superseded",
+            ]
+            assert row_data["active"] is False
+
+    remove_test_data(test_data)
+
+
+@parametrize_with_cases("test_data, data, expected_result, expected_last_updated_date,expected_status_code")
+def test_get_codes_broken(
+    mock_database,
+    mock_generate_code,
+    broken_update_codes,
+    caplog,
+    test_data,
+    data,
+    expected_result,
+    expected_last_updated_date,
+    expected_status_code,
+):
+
+    result, status_code = handle_revoke(data=data)
+
+    assert status_code == 500
+    with caplog.at_level(logging.ERROR):
+        assert "update_codes" in caplog.text

--- a/lambda_functions/v1/tests/api/test_mark_used_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_mark_used_handler_cases.py
@@ -29,7 +29,7 @@ def case_mark_a_code_as_used():
     expected_result = {"codes marked used": 1}
     expected_last_updated_date = test_constants["TODAY_ISO"]
     expected_status_code = 200
-    expected_expiry_date = two_years_from_now
+    expected_expiry_date = two_years_from_now()
     return (
         test_data,
         data,

--- a/lambda_functions/v1/tests/api/test_mark_used_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_mark_used_handler_cases.py
@@ -35,6 +35,7 @@ def case_mark_a_code_as_used():
         data,
         expected_result,
         expected_last_updated_date,
+        expected_status_code,
         expected_expiry_date,
     )
 
@@ -60,6 +61,7 @@ def case_mark_a_code_as_used_but_does_not_exist():
 
     expected_result = {"codes marked used": 0}
     expected_last_updated_date = "2019-12-26"
+    expected_expiry_date = two_years_from_now()
     expected_status_code = 200
     return (
         test_data,
@@ -67,4 +69,5 @@ def case_mark_a_code_as_used_but_does_not_exist():
         expected_result,
         expected_last_updated_date,
         expected_status_code,
+        expected_expiry_date,
     )

--- a/lambda_functions/v1/tests/api/test_mark_used_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_mark_used_handler_cases.py
@@ -3,10 +3,11 @@ import datetime
 from lambda_functions.v1.functions.lpa_codes.app.api.helpers import date_formatter
 from lambda_functions.v1.tests.conftest import test_constants
 from pytest_cases import case
+from test_mark_used_handler import two_years_from_now
 
 
-@case(id="Revoke an active code")
-def case_revoke_a_code_1():
+@case(id="Mark a code as used")
+def case_mark_a_code_as_used():
     test_data = [
         {
             "active": True,
@@ -25,52 +26,20 @@ def case_revoke_a_code_1():
         "code": "jmABs6fFaNJG",
     }
 
-    expected_result = {"codes revoked": 1}
+    expected_result = {"codes marked used": 1}
     expected_last_updated_date = test_constants["TODAY_ISO"]
     expected_status_code = 200
+    expected_expiry_date = two_years_from_now
     return (
         test_data,
         data,
         expected_result,
         expected_last_updated_date,
-        expected_status_code,
+        expected_expiry_date,
     )
 
-
-@case(id="Revoke an inactive code")
-def case_revoke_a_code_2():
-    test_data = [
-        {
-            "active": False,
-            "actor": "violet",
-            "code": "jmABs6fFaNJG",
-            "expiry_date": test_constants["EXPIRY_DATE"],
-            "generated_date": "2019-09-31",
-            "last_updated_date": "2019-12-26",
-            "dob": "1960-06-05",
-            "lpa": "700000000096",
-            "status_details": "Superseded",
-        }
-    ]
-
-    data = {
-        "code": "jmABs6fFaNJG",
-    }
-
-    expected_result = {"codes revoked": 0}
-    expected_last_updated_date = "2019-12-26"
-    expected_status_code = 200
-    return (
-        test_data,
-        data,
-        expected_result,
-        expected_last_updated_date,
-        expected_status_code,
-    )
-
-
-@case(id="Try to revoke a code but it doesn't exist")
-def case_revoke_a_code_3():
+@case(id="Try to mark a code as used but it doesn't exist")
+def case_mark_a_code_as_used_but_does_not_exist():
     test_data = [
         {
             "active": True,
@@ -81,7 +50,7 @@ def case_revoke_a_code_3():
             "last_updated_date": "2019-12-26",
             "dob": "1960-06-05",
             "lpa": "700000000096",
-            "status_details": "Revoked",
+            "status_details": "Generated",
         }
     ]
 
@@ -89,7 +58,7 @@ def case_revoke_a_code_3():
         "code": "not_a_code",
     }
 
-    expected_result = {"codes revoked": 0}
+    expected_result = {"codes marked used": 0}
     expected_last_updated_date = "2019-12-26"
     expected_status_code = 200
     return (

--- a/lambda_functions/v1/tests/api/test_mark_used_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_mark_used_handler_cases.py
@@ -1,0 +1,101 @@
+import datetime
+
+from lambda_functions.v1.functions.lpa_codes.app.api.helpers import date_formatter
+from lambda_functions.v1.tests.conftest import test_constants
+from pytest_cases import case
+
+
+@case(id="Revoke an active code")
+def case_revoke_a_code_1():
+    test_data = [
+        {
+            "active": True,
+            "actor": "violet",
+            "code": "jmABs6fFaNJG",
+            "expiry_date": test_constants["EXPIRY_DATE"],
+            "generated_date": "2019-09-31",
+            "last_updated_date": "2019-12-26",
+            "dob": "1960-06-05",
+            "lpa": "700000000096",
+            "status_details": "Generated",
+        }
+    ]
+
+    data = {
+        "code": "jmABs6fFaNJG",
+    }
+
+    expected_result = {"codes revoked": 1}
+    expected_last_updated_date = test_constants["TODAY_ISO"]
+    expected_status_code = 200
+    return (
+        test_data,
+        data,
+        expected_result,
+        expected_last_updated_date,
+        expected_status_code,
+    )
+
+
+@case(id="Revoke an inactive code")
+def case_revoke_a_code_2():
+    test_data = [
+        {
+            "active": False,
+            "actor": "violet",
+            "code": "jmABs6fFaNJG",
+            "expiry_date": test_constants["EXPIRY_DATE"],
+            "generated_date": "2019-09-31",
+            "last_updated_date": "2019-12-26",
+            "dob": "1960-06-05",
+            "lpa": "700000000096",
+            "status_details": "Superseded",
+        }
+    ]
+
+    data = {
+        "code": "jmABs6fFaNJG",
+    }
+
+    expected_result = {"codes revoked": 0}
+    expected_last_updated_date = "2019-12-26"
+    expected_status_code = 200
+    return (
+        test_data,
+        data,
+        expected_result,
+        expected_last_updated_date,
+        expected_status_code,
+    )
+
+
+@case(id="Try to revoke a code but it doesn't exist")
+def case_revoke_a_code_3():
+    test_data = [
+        {
+            "active": True,
+            "actor": "violet",
+            "code": "jmABs6fFaNJG",
+            "expiry_date": test_constants["EXPIRY_DATE"],
+            "generated_date": "2019-09-31",
+            "last_updated_date": "2019-12-26",
+            "dob": "1960-06-05",
+            "lpa": "700000000096",
+            "status_details": "Revoked",
+        }
+    ]
+
+    data = {
+        "code": "not_a_code",
+    }
+
+    expected_result = {"codes revoked": 0}
+    expected_last_updated_date = "2019-12-26"
+    expected_status_code = 200
+    return (
+        test_data,
+        data,
+        expected_result,
+        expected_last_updated_date,
+        expected_status_code,
+    )

--- a/lambda_functions/v1/tests/api/test_revoke_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_revoke_handler_cases.py
@@ -37,6 +37,37 @@ def case_revoke_a_code_1():
     )
 
 
+@case(id="Revoke a not yet used modernise code")
+def case_revoke_a_not_yet_used_modernise_code():
+    test_data = [
+        {
+            "active": True,
+            "actor": "violet",
+            "code": "jmABs6fFaNJG",
+            "generated_date": "2019-09-31",
+            "last_updated_date": "2019-12-26",
+            "dob": "1960-06-05",
+            "lpa": "M-3AC4-1274-AP1H",
+            "status_details": "Generated",
+        }
+    ]
+
+    data = {
+        "code": "jmABs6fFaNJG",
+    }
+
+    expected_result = {"codes revoked": 1}
+    expected_last_updated_date = test_constants["TODAY_ISO"]
+    expected_status_code = 200
+    return (
+        test_data,
+        data,
+        expected_result,
+        expected_last_updated_date,
+        expected_status_code,
+    )
+
+
 @case(id="Revoke an inactive code")
 def case_revoke_a_code_2():
     test_data = [

--- a/lambda_functions/v1/tests/api/test_validate_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_validate_handler_cases.py
@@ -27,6 +27,30 @@ def case_validate_valid_code_1():
     return test_data, data, expected_result, expected_status_code
 
 
+@case(id="Try to validate a modernise code with no expiry date")
+def case_validate_valid_code_1():
+    test_data = [
+        {
+            "active": True,
+            "actor": "lightcyan",
+            "code": "t39hg7zQdE59",
+            "generated_date": "2019-09-31",
+            "last_updated_date": "2019-12-26",
+            "dob": "1960-06-05",
+            "lpa": "M-3AC4-1274-AP1H",
+        }
+    ]
+
+    data = {
+        "lpa": "M-3AC4-1274-AP1H",
+        "dob": "1960-06-05",
+        "code": "t39hg7zQdE59",
+    }
+
+    expected_result = {"actor": "lightcyan"}
+    expected_status_code = 200
+    return test_data, data, expected_result, expected_status_code
+
 @case(id="Try to validate a code that is valid but not active")
 def case_validate_valid_code_2():
     test_data = [

--- a/lambda_functions/v1/tests/routes/test_mark_used.py
+++ b/lambda_functions/v1/tests/routes/test_mark_used.py
@@ -1,0 +1,63 @@
+import json
+
+import requests
+
+import pytest
+
+response_400 = {
+    "body": {"error": {"code": "Bad Request", "message": "Bad payload"}},
+    "headers": {"Content-Type": "application/json"},
+    "isBase64Encoded": False,
+    "statusCode": 400,
+}
+
+
+@pytest.mark.run(order=1)
+def test_mark_used(server):
+
+    with server.app_context():
+        test_data = {"code": "hdgeytkvnshd"}
+
+        test_headers = {"Content-Type": "application/json"}
+
+        expected_return = {"codes marked used": 0}
+
+        r = requests.post(
+            server.url + "/mark_used", headers=test_headers, data=json.dumps(test_data)
+        )
+        assert r.status_code == 200
+        assert r.json() == expected_return
+
+
+@pytest.mark.run(order=1)
+def test_mark_used_empty_code(server):
+
+    with server.app_context():
+        test_data = {"code": ""}
+
+        test_headers = {"Content-Type": "application/json"}
+
+        expected_return = response_400
+
+        r = requests.post(
+            server.url + "/mark_used", headers=test_headers, data=json.dumps(test_data)
+        )
+        assert r.status_code == 400
+        assert r.json() == expected_return
+
+
+@pytest.mark.run(order=1)
+def test_mark_used_missing_code(server):
+
+    with server.app_context():
+        test_data = {"banana": "chipmunk"}
+
+        test_headers = {"Content-Type": "application/json"}
+
+        expected_return = response_400
+
+        r = requests.post(
+            server.url + "/mark_used", headers=test_headers, data=json.dumps(test_data)
+        )
+        assert r.status_code == 400
+        assert r.json() == expected_return


### PR DESCRIPTION
## Purpose

_Enable expiry date to be set at the start of use for Modernise codes, vs the old codes which have expiry code set when created_

## Approach

- New mark_used endpoint to start the clock for codes. This is intended for Modernise codes but we allow this to be done for any code. With associated tests. 
- Mod to create endpoint, to only set expiry for old codes not Modernise ones i:e not for anything starting with M or m. Associated tests modified to test this. 
- Added a case to the validate tests that is missing an expiry date, to ensure nothing breaks
- OpenAPI spec updated_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
