### PR TITLE
UML-3302 for Modernise LPAs , do not revoke old codes in creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ so you don't need docker to be spun up to run them. You should use a virtualenv.
 Check you're in root of this repo then:
 
 ```
-virtualenv venv --python=python3.8
+virtualenv venv --python=python3.11
 source venv/bin/activate
 pip install -r ./lambda_functions/v1/requirements/requirements.txt
 pip install -r ./lambda_functions/v1/requirements/dev-requirements.txt

--- a/lambda_functions/v1/functions/lpa_codes/app/api/endpoints.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/endpoints.py
@@ -63,14 +63,15 @@ def handle_create(data):
 
         key = {"lpa": lpa, "actor": actor}
 
-        # 1. expire all existing codes for LPA/Actor combo
-        try:
-            code_generator.update_codes(
-                database=db, key=key, status=False, status_details="Superseded"
-            )
-        except Exception as e:
-            logger.error(f"Error in handle_create > get_codes: {e}")
-            return None, 500
+        # 1. for legacy (non-Modernise) LPAs only, expire all existing codes for LPA/Actor combo
+        if lpa[0] not in ('M' , 'm'):
+            try:
+                code_generator.update_codes(
+                    database=db, key=key, status=False, status_details="Superseded"
+                )
+            except Exception as e:
+                logger.error(f"Error in handle_create > get_codes: {e}")
+                return None, 500
 
         # 2. generate a new code
         try:

--- a/lambda_functions/v1/tests/api/test_create_handler.py
+++ b/lambda_functions/v1/tests/api/test_create_handler.py
@@ -75,8 +75,14 @@ def test_data(mock_database, mock_generate_code, test_data, data, expected_resul
                     else:
                         assert item["expiry_date"] == test_constants["EXPIRY_DATE"]
                 else:
-                    assert item["active"] is False
-                    assert item["status_details"] == "Superseded"
+                    # Existing Modernise codes should remain untouched
+                    if lpa[0] in ('M' , 'm'):
+                        assert item["active"] is True
+                        assert item["status_details"] == "Generated"
+                    else:
+                    # Existing Legacy codes should now be superseded
+                        assert item["active"] is False
+                        assert item["status_details"] == "Superseded"
         else:
             assert codes_created == expected_result
             break

--- a/lambda_functions/v1/tests/api/test_create_handler_cases.py
+++ b/lambda_functions/v1/tests/api/test_create_handler_cases.py
@@ -88,7 +88,7 @@ def case_create_a_modernise_code():
         "lpas": [
             {
                 "lpa": "M-3AF4-1274-A81H",
-                "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
+                "actor": "violet",
                 "dob": "1960-06-05",
             }
         ]
@@ -100,7 +100,7 @@ def case_create_a_modernise_code():
         "codes": [
             {
                 "lpa": "M-3AF4-1274-A81H",
-                "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac9b",
+                "actor": "violet",
                 "code": code,
             }
         ]


### PR DESCRIPTION
version

## Purpose

_For Modernise LPAs we do not wish to revoke existing codes when we create a new one_

## Approach

_Logic to only revoke existing codes for legacy LPAs. Mod to tests to reflect this_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
