### PR TITLE
handle AWS token in mock as well as existing hard-coded token

### DIFF
--- a/lambda_functions/v1/functions/lpa_codes/app/lpa_codes_mock.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/lpa_codes_mock.py
@@ -11,7 +11,12 @@ TOKEN_DB = {"asdf1234567890": {"uid": 100}}
 
 
 def apikey_auth(token, required_scopes):
-    info = TOKEN_DB.get(token, None)
+
+    # if we have been sent an AWS token, set it by hand
+    if token[0:16] == 'AWS4-HMAC-SHA256':
+        info = TOKEN_DB.get('asdf1234567890', None)
+    else:
+        info = TOKEN_DB.get(token, None)
 
     if not info:
         raise OAuthProblem("Invalid token")


### PR DESCRIPTION
## Purpose

_handle AWS token in mock as well as existing hard-coded token_

## Approach

_Allow a AWS token as well as the hard-coded one, in the python_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
