### PR TITLE
VEGA-2762 : Update the LPA Uid regex to accommodate MRLPA Uid #minor

### DIFF
--- a/lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml
+++ b/lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml
@@ -145,7 +145,7 @@ paths:
                     properties:
                       lpa:
                         type: string
-                        pattern: '[0-9]{12}|^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+                        pattern: '([0-9]{12}|^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})|(M(-[0-9A-Z]{4}){3})$'
                       actor:
                         type: string
                         pattern: '[0-9]{12}|^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'

--- a/lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml
+++ b/lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml
@@ -145,7 +145,7 @@ paths:
                     properties:
                       lpa:
                         type: string
-                        pattern: '([0-9]{12}|^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})|(M(-[0-9A-Z]{4}){3})$'
+                        pattern: '^([0-9]{12}|([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})|(M(-[0-9A-Z]{4}){3}))$'
                       actor:
                         type: string
                         pattern: '[0-9]{12}|^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'

--- a/lambda_functions/v1/tests/routes/test_create.py
+++ b/lambda_functions/v1/tests/routes/test_create.py
@@ -45,6 +45,37 @@ def test_create(server):
         assert r.status_code == 200
         assert r.json() == expected_return
 
+@pytest.mark.run(order=1)
+def test_create_digital_lpa(server):
+
+    with server.app_context():
+        test_data = {
+            "lpas": [
+                {
+                    "lpa": "M-3J8F-86JF-9UDA",
+                    "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac8e",
+                    "dob": "1960-06-05",
+                }
+            ]
+        }
+
+        test_headers = {"Content-Type": "application/json"}
+
+        expected_return = {
+            "codes": [
+                {
+                    "actor": "12ad81a9-f89d-4804-99f5-7c0c8669ac8e",
+                    "code": "tOhkrldOqewm",
+                    "lpa": "M-3J8F-86JF-9UDA",
+                }
+            ]
+        }
+
+        r = requests.post(
+            server.url + "/create", headers=test_headers, data=json.dumps(test_data)
+        )
+        assert r.status_code == 200
+        assert r.json() == expected_return
 
 @pytest.mark.run(order=1)
 def test_create_missing_lpa(server):


### PR DESCRIPTION
## Purpose

This PR covers [VEGA-2762](https://opgtransform.atlassian.net/browse/VEGA-2762) so that a code can be generated for the MRLPA actors using the M- type MRLPA Uids.

## Approach

There is a regex pattern set for the LPA parameter in the API gateway in the /create endpoint specified in the [lpa-codes-openapi-v1](https://github.com/ministryofjustice/opg-data-lpa-codes/blob/33b0761677c8348d86b27e1fed32e96ef7eddced/lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml). This regex pattern does not accommodate the MRLPA Uids. So an update has been made to this pattern so that it can cater for both Legacy and Digital LPA Uids.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [X] I have added tests to prove my work
* [ ] The product team have tested these changes


[VEGA-2762]: https://opgtransform.atlassian.net/browse/VEGA-2762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ