### PR TITLE
Remove hardcoded port 8000 and setup local config to continue to work as if nothing's changed

### DIFF
--- a/docker-compose-pact.yml
+++ b/docker-compose-pact.yml
@@ -35,7 +35,7 @@ services:
     depends_on:
       - dynamodb
     environment:
-      LOCAL_URL: dynamodb
+      LOCAL_URL: http://dynamodb:8000
       ENVIRONMENT: local
       AWS_ACCESS_KEY_ID: testing
       AWS_SECRET_ACCESS_KEY: testing #pragma: allowlist secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - dynamodb
       - table-helper
     environment:
-      LOCAL_URL: host.docker.internal
+      LOCAL_URL: http://dynamodb:8000
       ENVIRONMENT: local
       API_VERSION: v1
       AWS_ACCESS_KEY_ID: testing
@@ -34,7 +34,7 @@ services:
     volumes:
       - ./lambda_functions/v1/:/var/www/lambda_functions/v1/
     environment:
-      LOCAL_URL: host.docker.internal
+      LOCAL_URL: http://dynamodb:8000
       ENVIRONMENT: local
       AWS_ACCESS_KEY_ID: testing
       AWS_SECRET_ACCESS_KEY: testing #pragma: allowlist secret

--- a/lambda_functions/v1/functions/lpa_codes/app/api/database.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/database.py
@@ -21,9 +21,9 @@ def db_connection():
         if os.environ.get("LOCAL_URL"):
             url = os.environ.get("LOCAL_URL")
         else:
-            url = "localhost"
+            url = "http://localhost:8000"
         conn = boto3.resource(
-            "dynamodb", endpoint_url="http://" + url + ":8000", region_name="eu-west-1"
+            "dynamodb", endpoint_url=url, region_name="eu-west-1"
         )
         logger.info(f"Connecting to local Docker database container with url: {url}")
     else:

--- a/lambda_functions/v1/functions/lpa_codes/app/lpa_codes_mock.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/lpa_codes_mock.py
@@ -28,17 +28,17 @@ def dynamodb_connection(conn="resource"):
     if os.environ.get("LOCAL_URL") is not None:
         local_url = os.environ.get("LOCAL_URL")
     else:
-        local_url = "localhost"
+        local_url = "http://localhost:8000"
     if conn == "resource":
         ddb = boto3.resource(
             "dynamodb",
-            endpoint_url="http://" + local_url + ":8000",
+            endpoint_url=local_url,
             region_name="eu-west-1",
         )
     else:
         ddb = boto3.client(
             "dynamodb",
-            endpoint_url="http://" + local_url + ":8000",
+            endpoint_url=local_url,
             region_name="eu-west-1",
         )
     return ddb

--- a/lambda_functions/v1/tests/other/test_db_connection.py
+++ b/lambda_functions/v1/tests/other/test_db_connection.py
@@ -32,7 +32,7 @@ def test_db_connection(monkeypatch, caplog):
         assert "localhost" in caplog.text
 
     monkeypatch.setenv("ENVIRONMENT", "local")
-    monkeypatch.setenv("LOCAL_URL", "host.docker.internal")
+    monkeypatch.setenv("LOCAL_URL", "http://host.docker.internal:8000")
 
     db_connection()
 
@@ -50,7 +50,7 @@ def test_db_connection(monkeypatch, caplog):
         assert "localhost" in caplog.text
 
     monkeypatch.setenv("ENVIRONMENT", "ci")
-    monkeypatch.setenv("LOCAL_URL", "host.docker.internal")
+    monkeypatch.setenv("LOCAL_URL", "http://host.docker.internal:8000")
 
     db_connection()
 

--- a/lambda_functions/v1/tests/other/test_db_connection.py
+++ b/lambda_functions/v1/tests/other/test_db_connection.py
@@ -41,7 +41,6 @@ def test_db_connection(monkeypatch, caplog):
         assert "host.docker.internal" in caplog.text
 
     monkeypatch.setenv("ENVIRONMENT", "ci")
-    monkeypatch.setenv("LOCAL_URL", None)
 
     db_connection()
 


### PR DESCRIPTION
## Purpose

Stop hardcoding port 8000 in the mock service so that the Use project can use localstacks 4566 instead.

## Approach

If a special port is required that should be a part of the URL that a user has to configure. Local docker-compose 

## Checklist

* [x] I have performed a self-review of my own code
