### PR TITLE
(POC) Validate requests/responses against OpenAPI spec

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./lambda_functions/.aws-lambda-rie:/aws-lambda
       - ./lambda_functions/v1/functions/lpa_codes/app:/function/app
+      - ./lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml:/openapi/lpa-codes-openapi-v1.yml
     depends_on:
       - dynamodb
       - table-helper
@@ -21,6 +22,7 @@ services:
       AWS_SECURITY_TOKEN: testing
       AWS_SESSION_TOKEN: testing
       AWS_DEFAULT_REGION: eu-west-1
+      OPENAPI_SPEC_PATH: /openapi/lpa-codes-openapi-v1.yml
     entrypoint: /aws-lambda/aws-lambda-rie /usr/local/bin/python -m awslambdaric app.lpa_codes.lambda_handler
 
   table-helper:
@@ -41,6 +43,7 @@ services:
       AWS_SECURITY_TOKEN: testing
       AWS_SESSION_TOKEN: testing
       AWS_DEFAULT_REGION: eu-west-1
+      OPENAPI_SPEC_PATH: /var/www/lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml
 
   dynamodb:
     image: amazon/dynamodb-local:latest

--- a/docs/support_files/lambda_request.json
+++ b/docs/support_files/lambda_request.json
@@ -69,6 +69,7 @@
 		"Host": "dev.lpa-codes.api.opg.service.justice.gov.uk",
 		"X-Forwarded-Proto": "https",
 		"x-amz-security-token": "redacted",
-		"content-type": "application/json; charset=utf-8"
+		"content-type": "application/json; charset=utf-8",
+		"Authorization": "apikey"
 	}
 }

--- a/lambda_functions/v1/functions/lpa_codes/app/api/resources.py
+++ b/lambda_functions/v1/functions/lpa_codes/app/api/resources.py
@@ -1,6 +1,8 @@
 import os
 
 from flask import Blueprint, abort, request, jsonify
+from openapi_core import OpenAPI
+from openapi_core.contrib.flask.decorators import FlaskOpenAPIViewDecorator
 
 from .errors import error_message
 from .helpers import custom_logger
@@ -10,6 +12,9 @@ logger = custom_logger("code generator")
 
 version = os.getenv("API_VERSION")
 api = Blueprint("api", __name__, url_prefix=f"/{version}")
+
+openapi = OpenAPI.from_file_path(os.getenv("OPENAPI_SPEC_PATH", "./lambda_functions/v1/openapi/lpa-codes-openapi-v1.yml"))
+openapi_validated = FlaskOpenAPIViewDecorator(openapi)
 
 
 @api.app_errorhandler(404)
@@ -33,6 +38,7 @@ def handle500(error=None):
 
 
 @api.route("/healthcheck", methods=["HEAD", "GET"])
+@openapi_validated
 def handle_healthcheck():
     response_message = "OK"
 
@@ -40,6 +46,7 @@ def handle_healthcheck():
 
 
 @api.route("/create", methods=["POST"])
+@openapi_validated
 def create_route():
     """
     Creates a new code for the given lpa/actor/dob combo.
@@ -73,6 +80,7 @@ def create_route():
 
 
 @api.route("/revoke", methods=["POST"])
+@openapi_validated
 def revoke_route():
     """
     Revokes the given code
@@ -100,7 +108,9 @@ def revoke_route():
 
     return jsonify(result), status_code
 
+
 @api.route("/mark_used", methods=["POST"])
+@openapi_validated
 def mark_used_route():
     """
     Marks the given code as used (sets the expiry date)
@@ -128,7 +138,9 @@ def mark_used_route():
 
     return jsonify(result), status_code
 
+
 @api.route("/validate", methods=["POST"])
+@openapi_validated
 def validate_route():
     """
     Validates a code/lpa/dob combo
@@ -163,6 +175,7 @@ def validate_route():
 
 
 @api.route("/exists", methods=["POST"])
+@openapi_validated
 def actor_code_exists_route():
     """
     Checks if a code exists for a given actor on an LPA
@@ -195,6 +208,7 @@ def actor_code_exists_route():
 
 
 @api.route("/code", methods=["POST"])
+@openapi_validated
 def actor_code_details_route():
     """
     Returns data for an Actor Activation code

--- a/lambda_functions/v1/requirements/requirements.txt
+++ b/lambda_functions/v1/requirements/requirements.txt
@@ -2,3 +2,4 @@
 awslambdaric==2.0.7
 flask==3.0.2
 boto3~=1.28
+openapi-core==0.19.5


### PR DESCRIPTION
## Purpose

If the request or response doesn't match the OpenAPI spec, this plugin will fail the request. This allows us to detect drift from the spec during development and tests, and in real environments.

In reality this should only be run in non-production environments.

## Approach

The `openapi-core` decorator intercepts requests and check that the request and response match the OpenAPI spec. If not, it returns an error explaining the divergence instead.
