### PR TITLE
UML-4077 - upgrade allow list for new ual cidr ranges

### DIFF
--- a/terraform/environment/api_rest.tf
+++ b/terraform/environment/api_rest.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "lpa_rest_api_ip_restriction_policy" {
 }
 
 module "allow_list" {
-  source = "git@github.com:ministryofjustice/opg-terraform-aws-moj-ip-allow-list.git?ref=v3.4.4"
+  source = "git@github.com:ministryofjustice/opg-terraform-aws-moj-ip-allow-list.git?ref=v3.4.5"
 }
 
 locals {


### PR DESCRIPTION
## Purpose

Allow new Make an LPA and Use an LPA networks to use the LPA data API

## Approach

- upgraded allow list module to fetch new nat gateway CIDR ranges

## Learning

- https://github.com/ministryofjustice/opg-terraform-aws-moj-ip-allow-list/pull/51
