### PR TITLE
UML-4079 - upgrade alpine to 3.22

### DIFF
--- a/lambda_functions/v1/Dockerfile-Function
+++ b/lambda_functions/v1/Dockerfile-Function
@@ -1,7 +1,7 @@
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-FROM python:3.13-alpine3.19@sha256:8287ca207e905649e9f399b5f91a119e5e9051d8cd110d5f8c3b4bd9458ebd1d AS python-alpine
+FROM python:3.13-alpine3.22@sha256:9ba6d8cbebf0fb6546ae71f2a1c14f6ffd2fdab83af7fa5669734ef30ad48844 AS python-alpine
 RUN apk add --no-cache \
     libstdc++ \
     elfutils-dev


### PR DESCRIPTION
## Purpose

Vulnerability found in pip, fixed in later verson of the image.

## Approach

- upgrade python:3.13-alpine3.19 image to alpine 3.22

## Learning

- https://hub.docker.com/layers/library/python/3.13-alpine3.22/images/sha256-9f6ef716c6b05489cd3cc2222a2f49859513858035677da4f3dadcd5092bb945