### PR TITLE
UML-4322: Pin pre-commit & update renovate config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
         args:
           - --branch=main
   - repo: https://github.com/python-openapi/openapi-spec-validator
-    rev: 0.7.1
+    rev: cca400fbe29ebaea5c3b3e7db04548db260690ea # frozen: 0.8.4
     hooks:
       - id: openapi-spec-validator
         name: openapi-spec-validator
@@ -18,31 +18,19 @@ repos:
         description: Hook to validate Open API specs.
         language: python
         files: .*lpa-codes-openapi-aws.compiled.*\.(json|yaml|yml)
-  - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.17.0
-    hooks:
-      - id: yamllint
-        args: [-c=./.yamllint]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.4
+    rev: d0e12caebb2ab0ee8bf98181c8bfe9702bca103d  # frozen: v1.105.0
     hooks:
       - id: terraform_fmt
       - id: terraform_tflint
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
+  - repo: https://github.com/TekWizely/pre-commit-golang
+    rev: f298c082154b2cb239fac06a4f452368e66e66dd # frozen: v1.0.0-rc.4
     hooks:
       - id: go-fmt
       - id: go-imports
       - id: go-mod-tidy
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
-    hooks:
-      - id: trailing-whitespace
-      - id: detect-private-key
-      - id: trailing-whitespace
-        args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+    rev: 68e8b45440415753fff70a312ece8da92ba85b4a  # frozen: v1.5.0
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -27,6 +27,9 @@
       "name": "GitHubTokenDetector"
     },
     {
+      "name": "GitLabTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
@@ -35,6 +38,9 @@
     },
     {
       "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
     },
     {
       "name": "JwtTokenDetector"
@@ -50,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -68,16 +80,15 @@
       "name": "StripeDetector"
     },
     {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
       "name": "TwilioKeyDetector"
     }
   ],
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -112,51 +123,43 @@
     }
   ],
   "results": {
-    ".circleci/config.yml": [
+    ".pre-commit-config.yaml": [
       {
         "type": "Hex High Entropy String",
-        "filename": ".circleci/config.yml",
-        "hashed_secret": "0f2f26ce9b2dc4c459e902c7422315d38da2f535",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "26f89e75489173ffe046cc843b9a983e65020901",
         "is_verified": false,
-        "line_number": 51
-      }
-    ],
-    "lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py": [
+        "line_number": 4
+      },
       {
-        "type": "Base64 High Entropy String",
-        "filename": "lambda_functions/v1/functions/lpa_codes/app/api/code_generator.py",
-        "hashed_secret": "2f016bd24ca70fb95baf5d88556b3e92c50ae271",
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "b81e16e5e653c7ec96720d3446ad8d1e6e7a06c5",
         "is_verified": false,
-        "line_number": 24
-      }
-    ],
-    "lambda_functions/v1/tests/conftest.py": [
+        "line_number": 13
+      },
       {
-        "type": "Secret Keyword",
-        "filename": "lambda_functions/v1/tests/conftest.py",
-        "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "384557cbc10c11a779cbe5ce8fd9838d2adf434b",
         "is_verified": false,
-        "line_number": 95
-      }
-    ],
-    "lambda_functions/v1/tests/routes/conftest.py": [
+        "line_number": 22
+      },
       {
-        "type": "Secret Keyword",
-        "filename": "lambda_functions/v1/tests/routes/conftest.py",
-        "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "780351622914d813ee8b73df3a697d2ec075d1e8",
         "is_verified": false,
-        "line_number": 77
-      }
-    ],
-    "pytest.ini": [
+        "line_number": 27
+      },
       {
-        "type": "Secret Keyword",
-        "filename": "pytest.ini",
-        "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "86242b7a7b67c1fd83514757a6b319602d648e94",
         "is_verified": false,
-        "line_number": 7
+        "line_number": 33
       }
     ]
   },
-  "generated_at": "2025-10-16T14:54:35Z"
+  "generated_at": "2026-04-13T08:11:36Z"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -42,7 +42,6 @@
       ],
       "prCreation": "immediate",
       "prPriority": 0,
-      "minimumReleaseAge": "3 days",
       "matchPackageNames": [
         "*"
       ]
@@ -61,7 +60,6 @@
       "schedule": [
         "after 6am and before 9am on Monday"
       ],
-      "minimumReleaseAge": "3 days",
       "matchPackageNames": [
         "/actions/*/"
       ]
@@ -77,6 +75,7 @@
     "prPriority": 1
   },
   "branchConcurrentLimit": 5,
+  "minimumReleaseAge": "7 days",
   "prConcurrentLimit": 3,
   "prHourlyLimit": 1,
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Purpose

Updates Renovate to use a minimum release age of 7 days across all packages, and additionally pins pre-commit hooks to SHA's.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
